### PR TITLE
Add initial tokenizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(cthusly
 	src/common.h
 	src/debug.h
 	src/debug.c
+	src/exit_code.h
 	src/memory.h
 	src/memory.c
 	src/program.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,11 @@ set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin)
 add_subdirectory(src)
 
 # add_executable(cthusly src/main.c)
-
 add_executable(cthusly
 	src/main.c
 	src/common.h
+	src/compiler.h
+	src/compiler.c
 	src/debug.h
 	src/debug.c
 	src/exit_code.h
@@ -24,10 +25,11 @@ add_executable(cthusly
 	src/program.c
 	src/thusly_value.h
 	src/thusly_value.c
+	src/tokenizer.h
+	src/tokenizer.c
 	src/vm.h
 	src/vm.c
 )
 
 target_include_directories(cthusly PUBLIC src)
-
 # target_link_libraries(cthusly PUBLIC ..)

--- a/grammar/grammar.txt
+++ b/grammar/grammar.txt
@@ -57,7 +57,7 @@ unary:
 	| atom								# TODO: Change to `call` when adding calls
 
 atom:
-	IDENTIFIER
+	| IDENTIFIER
 	| NUMBER
 	| TEXT
 	| "true"
@@ -79,7 +79,7 @@ NUMBER:
 	| DIGIT+ ( "." DIGIT+ )?
 
 TEXT:
-	| "\"" <any ASCII character except "\"" or NEWLINE>* "\""
+	| "\"" <any ASCII character except "\"">* "\""
 
 ALPHA:
 	| "a" ... "z"
@@ -90,9 +90,9 @@ DIGIT:
 	| "0" ... "9"
 
 NEWLINE:
-    | "\n"
-    | "\r"
-    | "\r\n"
+	| "\n"
+	| "\r"
+	| "\r\n"
 
 FILE_END:
-    | <end of file>
+	| <end of file>

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+#include "common.h"
+#include "compiler.h"
+#include "tokenizer.h"
+
+void compile(VM* vm, const char* source) {
+  Tokenizer tokenizer;
+  init_tokenizer(&tokenizer, source);
+
+  int line = -1;
+  while (true) {
+    Token token = tokenize(&tokenizer);
+    bool same_line_as_previous = token.line == line;
+    if (same_line_as_previous)
+      printf("           ");
+    else {
+      printf("line[%4d] ", token.line);
+      line = token.line;
+    }
+    // `token.length` is passed as the argument for '*' (determining how many
+    // characters of `token.start` to display). E.g. tokentype[15] lexeme[else]'.
+    printf("tokentype[%2d] lexeme[%.*s]\n", token.type, token.length, token.lexeme); 
+
+    if (token.type == TOKEN_FILE_END)
+      break;
+  }
+}

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -1,0 +1,8 @@
+#ifndef CTHUSLY_COMPILER_H
+#define CTHUSLY_COMPILER_H
+
+#include "vm.h"
+
+void compile(VM* vm, const char* source);
+
+#endif

--- a/src/exit_code.h
+++ b/src/exit_code.h
@@ -1,0 +1,14 @@
+#ifndef CTHUSLY_EXIT_CODE_H
+#define CTHUSLY_EXIT_CODE_H
+
+/// Program exit code (UNIX).
+/// (see https://www.freebsd.org/cgi/man.cgi?query=sysexits&apropos=0&sektion=0&manpath=FreeBSD+13.1-RELEASE&arch=default&format=html)
+typedef enum {
+  EXIT_CODE_USAGE_ERROR = 64,
+  EXIT_CODE_INPUT_DATA_ERROR = 65,
+  EXIT_CODE_INPUT_FILE_ERROR = 66,
+  EXIT_CODE_INTERNAL_SOFTWARE_ERROR = 70,
+  EXIT_CODE_IO_OP_ERROR = 74,
+} ExitCode;
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,47 +1,90 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "common.h"
 #include "debug.h"
+#include "exit_code.h"
 #include "program.h"
 #include "vm.h"
+
+static void print_help() {
+  fprintf(stderr, "Run in interactive mode: ./cthusly\nExecute a file: ./cthusly path/to/file\n");
+}
+
+static void run_repl(VM* vm) {
+  char line[1024];
+  while (true) {
+    printf("> ");
+    // Only handling single-line inputs.
+    if (!fgets(line, sizeof(line), stdin)) {
+      printf("\n");
+      break;
+    }
+
+    interpret(vm, line);
+  }
+}
+
+static char* read_file(const char* path) {
+  FILE* file = fopen(path, "rb");
+  if (file == NULL) {
+    fprintf(stderr, "The file could not be opened (\"%s\").", path);
+    exit(EXIT_CODE_IO_OP_ERROR);
+  }
+
+  // Going to the end of the file (`fseek()`) and checking how many bytes there are (`ftell()`)
+  // determines the size of the source/string buffer needed when allocating it (`malloc()`).
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  rewind(file);
+
+  // Add +1 for terminating the string (null byte).
+  char* source_buffer = (char*)malloc(file_size + 1);
+  if (source_buffer == NULL) {
+    fprintf(stderr, "There was not enough memory available to read the file (\"%s\").", path);
+    exit(EXIT_CODE_IO_OP_ERROR);
+  }
+
+  // Read from the file and into the allocated string buffer.
+  size_t num_bytes_read = fread(source_buffer, sizeof(char), file_size, file);
+  if (num_bytes_read < file_size) {
+    fprintf(stderr, "The file could not be read (\"%s\").", path);
+    exit(EXIT_CODE_IO_OP_ERROR);
+  }
+  source_buffer[num_bytes_read] = '\0';
+
+  fclose(file);
+
+  return source_buffer;
+}
+
+static void run_file(VM* vm, const char* path) {
+  char* source = read_file(path);
+  ErrorReport report = interpret(vm, source);
+  // `read_file()` uses `malloc()` for the source, thus it needs to be freed here.
+  free(source);
+
+  if (report == REPORT_COMPILE_ERROR)
+    exit(EXIT_CODE_INPUT_DATA_ERROR);
+  if (report == REPORT_RUNTIME_ERROR)
+    exit(EXIT_CODE_INTERNAL_SOFTWARE_ERROR);
+}
 
 int main(int argc, const char* argv[]) {
   VM vm;
   init_vm(&vm);
-  Program program;
-  init_program(&program);
-
-  // Temporary for debugging:
-  // -((20.5 + 11.5) / 4)
-  // Expected behavior (no precedence, only left-to-right at the moment):
-  // 1) 20.5 + 11.5 = 32
-  // 2) 32 / 4 = 8
-  // 3) -(8) = -8
-  // 4) -8
-  int constant_index = add_constant(&program, 20.5);
-  append_instruction(&program, OP_CONSTANT, 1);
-  append_instruction(&program, constant_index, 1);
-
-  constant_index = add_constant(&program, 11.5);
-  append_instruction(&program, OP_CONSTANT, 1);
-  append_instruction(&program, constant_index, 1);
-
-  append_instruction(&program, OP_ADD, 1);
-
-  constant_index = add_constant(&program, 4);
-  append_instruction(&program, OP_CONSTANT, 1);
-  append_instruction(&program, constant_index, 1);
-
-  append_instruction(&program, OP_DIVIDE, 1);
-
-  append_instruction(&program, OP_NEGATE, 1);
-
-  append_instruction(&program, OP_RETURN, 2);
-
-  disassemble_program(&program, "Program");
-
-  interpret(&vm, &program);
+  
+  if (argc == 1)
+    run_repl(&vm);
+  else if (argc == 2)
+    run_file(&vm, argv[1]);
+  else {
+    print_help();
+    exit(EXIT_CODE_USAGE_ERROR);
+  }
 
   free_vm(&vm);
-  free_program(&program);
 
   return 1;
 }

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -1,0 +1,11 @@
+#include "tokenizer.h"
+
+void init_tokenizer(Tokenizer* tokenizer, const char* source) {
+  tokenizer->start = source;
+  tokenizer->current = source;
+  tokenizer->line = 1;
+}
+
+Token tokenize(Tokenizer* tokenizer) {
+  // TODO
+}

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -1,3 +1,6 @@
+#include <string.h>
+
+#include "common.h"
 #include "tokenizer.h"
 
 void init_tokenizer(Tokenizer* tokenizer, const char* source) {
@@ -6,6 +9,82 @@ void init_tokenizer(Tokenizer* tokenizer, const char* source) {
   tokenizer->line = 1;
 }
 
+static bool is_at_end(Tokenizer* tokenizer) {
+  return *tokenizer->current == '\0';
+}
+
+static char advance(Tokenizer* tokenizer) {
+  tokenizer->current++;
+
+  return tokenizer->current[-1];
+}
+
+static bool match(Tokenizer* tokenizer, char expected) {
+  if (is_at_end(tokenizer) || *tokenizer->current != expected)
+    return false;
+
+  advance(tokenizer);
+
+  return true;
+}
+
+static Token make_token(Tokenizer* tokenizer, TokenType type) {
+  Token token;
+  token.type = type;
+  token.lexeme = tokenizer->start;
+  token.length = (int)(tokenizer->current - tokenizer->start);
+  token.line = tokenizer->line;
+
+  return token;
+}
+
+static Token make_error_token(Tokenizer* tokenizer, const char* message) {
+  Token token;
+  token.type = TOKEN_ERROR;
+  token.lexeme = message;
+  token.length = (int)(strlen(message));
+  token.line = tokenizer->line;
+
+  return token;
+}
+
 Token tokenize(Tokenizer* tokenizer) {
-  // TODO
+  tokenizer->start = tokenizer->current;
+
+  if (is_at_end(tokenizer))
+    return make_token(tokenizer, TOKEN_FILE_END);
+  
+  char character = advance(tokenizer);
+  switch (character) {
+    case ':':
+      return make_token(tokenizer, TOKEN_COLON);
+    case '(':
+      return make_token(tokenizer, TOKEN_OPEN_PAREN);
+    case ')':
+      return make_token(tokenizer, TOKEN_CLOSE_PAREN);
+    case '+':
+      return make_token(tokenizer, TOKEN_PLUS);
+    case '-':
+      return make_token(tokenizer, TOKEN_MINUS);
+    case '*':
+      return make_token(tokenizer, TOKEN_STAR);
+    case '/':
+      return make_token(tokenizer, TOKEN_SLASH);
+    case '=':
+      return make_token(tokenizer, TOKEN_EQUALS);
+    case '!':
+      if (match(tokenizer, '='))
+        return make_token(tokenizer, TOKEN_EXCLAMATION_EQUALS);
+      return make_error_token(tokenizer, "You have included an illegal character: !");
+    case '<':
+      return match(tokenizer, '=')
+        ? make_token(tokenizer, TOKEN_LESS_THAN_EQUALS)
+        : make_token(tokenizer, TOKEN_LESS_THAN);
+    case '>':
+      return match(tokenizer, '=')
+        ? make_token(tokenizer, TOKEN_GREATER_THAN_EQUALS)
+        : make_token(tokenizer, TOKEN_GREATER_THAN);
+  }
+  
+  return make_error_token(tokenizer, "You have included an illegal character");
 }

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -1,6 +1,8 @@
 #ifndef CTHUSLY_TOKENIZER_H
 #define CTHUSLY_TOKENIZER_H
 
+#include "common.h"
+
 // Some of the token types (incrementally added).
 
 typedef enum {
@@ -63,6 +65,7 @@ typedef struct {
   const char* start;
   const char* current;
   int line;
+  bool is_blank_line;
 } Tokenizer;
 
 void init_tokenizer(Tokenizer* tokenizer, const char* source);

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -1,0 +1,71 @@
+#ifndef CTHUSLY_TOKENIZER_H
+#define CTHUSLY_TOKENIZER_H
+
+// Some of the token types (incrementally added).
+
+typedef enum {
+  // Punctuation and non-keyword operators
+  TOKEN_CLOSE_PAREN,
+  TOKEN_COLON,
+  // TOKEN_COMMA,
+  // TOKEN_DOT,
+  TOKEN_EXCLAMATION_EQUALS,
+  TOKEN_EQUALS,
+  TOKEN_GREATER_THAN,
+  TOKEN_GREATER_THAN_EQUALS,
+  TOKEN_LESS_THAN,
+  TOKEN_LESS_THAN_EQUALS,
+  TOKEN_MINUS,
+  TOKEN_OPEN_PAREN,
+  TOKEN_PLUS,
+  TOKEN_SLASH,
+  TOKEN_STAR,
+
+  // Reserved keywords
+  TOKEN_AND,
+  // TOKEN_CONST,
+  // TOKEN_ELSE,
+  // TOKEN_END,
+  TOKEN_FALSE,
+  // TOKEN_FUN,
+  // TOKEN_IF,
+  TOKEN_NONE,
+  TOKEN_NOT,
+  TOKEN_OR,
+  // TOKEN_RETURN,
+  TOKEN_TRUE,
+  TOKEN_VAR,
+
+  // Literals
+  TOKEN_IDENTIFIER,
+  TOKEN_NUMBER,
+  TOKEN_TEXT,
+
+  // Formatting
+  // TOKEN_BLOCK,
+  TOKEN_FILE_END,
+  TOKEN_NEWLINE,
+
+  // Errors
+  TOKEN_ERROR,
+} TokenType;
+
+typedef struct {
+  TokenType type;
+  // This points into the original source (thus, the source
+  // is freed only after it has finished being interpreted).
+  const char* lexeme;
+  int length;
+  int line;
+} Token;
+
+typedef struct {
+  const char* start;
+  const char* current;
+  int line;
+} Tokenizer;
+
+void init_tokenizer(Tokenizer* tokenizer, const char* source);
+Token tokenize(Tokenizer* tokenizer);
+
+#endif

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -34,6 +34,7 @@ typedef enum {
   TOKEN_NONE,
   TOKEN_NOT,
   TOKEN_OR,
+  TOKEN_PRINT,    // Temporary until built-in function exists
   // TOKEN_RETURN,
   TOKEN_TRUE,
   TOKEN_VAR,

--- a/src/vm.c
+++ b/src/vm.c
@@ -110,9 +110,6 @@ static ErrorReport decode_and_execute(VM* vm) {
   #undef READ_CONSTANT
 }
 
-ErrorReport interpret(VM* vm, Program* program) {
-  vm->program = program;
-  vm->next_instruction = vm->program->instructions;
-
-  return decode_and_execute(vm);
+ErrorReport interpret(VM* vm, const char* source) {
+  return REPORT_NO_ERROR;
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 
 #include "common.h"
+#include "compiler.h"
 #include "debug.h"
 #include "program.h"
 #include "thusly_value.h"
@@ -111,5 +112,7 @@ static ErrorReport decode_and_execute(VM* vm) {
 }
 
 ErrorReport interpret(VM* vm, const char* source) {
+  compile(vm, source);
+
   return REPORT_NO_ERROR;
 }

--- a/src/vm.h
+++ b/src/vm.h
@@ -24,6 +24,6 @@ void init_vm(VM* vm);
 void free_vm(VM* vm);
 void push(VM* vm, ThuslyValue value);
 ThuslyValue pop(VM* vm);
-ErrorReport interpret(VM* vm, Program* program);
+ErrorReport interpret(VM* vm, const char* source);
 
 #endif


### PR DESCRIPTION
Adds the tokenizer (lexer) responsible for creating tokens from the source code.

This initial version tokenizes:
* Arithmetic operators
  * `+`, `-`, `*`, `/`
* Comparison operators
  * `<`, `<=`, `>`, `>=`, `=` , `!=`
* Grouping operators
  * `(`, `)` 
* Assignment operator
  * `:`
* Text (strings)
  * `"Some text"` 
* Numbers
  * `0.5`, `2`
* A subset of the keywords
  * `and`, `or`, `true`, `false`, `none`, `not`, `print`, `var`
* Identifiers
* Significant newlines

`main.c` has also been updated to allow:
* Reading a source file.
  * Run: `./cthusly path/to/file`
* Running the repl.
  * Run: `./cthusly`
* *(Requires building the binary)*