### PR TITLE
Add initial compiler and parser

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define DEBUG_COMPILATION
 #define DEBUG_EXECUTION
 
 typedef uint8_t byte;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -30,9 +30,9 @@ static void error_at(Parser* parser, Token* token, const char* message) {
   fprintf(stderr, "ERROR on line %d", token->line);
   if (token->type == TOKEN_FILE_END)
     fprintf(stderr, " at the end of the file.");
-  else if (token->type == TOKEN_ERROR) {
-    // The error message for `TOKEN_ERROR`s has been passed in as the
-    // `message` via `advance()`. There's no need to do anything here.
+  else if (token->type == TOKEN_LEXICAL_ERROR) {
+    // The error message for `TOKEN_LEXICAL_ERROR`s has been passed in as
+    // the `message` via `advance()`. There's no need to do anything here.
   }
   else {
     // `token->length` is passed as the argument for '*' (determining how many
@@ -53,15 +53,14 @@ static bool check(Parser* parser, TokenType type) {
 
 static void advance(Parser* parser, Tokenizer* tokenizer) {
   parser->previous = parser->current;
-  
-  while (true) {
-    parser->current = tokenize(tokenizer);
-    if (parser->current.type != TOKEN_ERROR)
-      break;
+  parser->current = tokenize(tokenizer);
 
-    // Whenever the tokenizer encounters an error it produces a token of
-    // type `TOKEN_ERROR` and saves the error message as the lexeme.
+  // Whenever the tokenizer encounters an error it produces a token of type
+  // `TOKEN_LEXICAL_ERROR`. Loop past (and report) these until the next valid token.
+  while (parser->current.type == TOKEN_LEXICAL_ERROR) {
+    // Lexical error tokens store the error message on the lexeme field.
     error_at(parser, &parser->current, parser->current.lexeme);
+    parser->current = tokenize(tokenizer);
   }
 }
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1,28 +1,88 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "common.h"
 #include "compiler.h"
 #include "tokenizer.h"
 
-void compile(VM* vm, const char* source) {
+// TODO: Perhaps move this struct to .h
+typedef struct {
+  Token current;
+  Token previous;
+  bool has_error;
+  bool panic_mode;
+} Parser;
+
+static void init_parser(Parser* parser) {
+  parser->has_error = false;
+  parser->panic_mode = false;
+}
+
+static void error_at(Parser* parser, Token* token, const char* message) {
+  // If the parser is in panic mode, return here in order to not report
+  // potentially false and unhelpful cascaded errors.
+  if (parser->panic_mode)
+    return;
+
+  parser->panic_mode = true;
+  parser->has_error = true;
+
+  fprintf(stderr, "ERROR on line %d", token->line);
+  if (token->type == TOKEN_FILE_END)
+    fprintf(stderr, " at the end of the file.");
+  else if (token->type == TOKEN_ERROR) {
+    // The error message for `TOKEN_ERROR`s has been passed in as the
+    // `message` via `advance()`. There's no need to do anything here.
+  }
+  else {
+    // `token->length` is passed as the argument for '*' (determining how many
+    // characters of `token->lexeme` to display). E.g. tokentype[13] lexeme[and]'.
+    fprintf(stderr, " at '%.*s'", token->length, token->lexeme);
+  }
+
+  fprintf(stderr, ":\n\t>> Help: %s\n", message);
+}
+
+static void error(Parser* parser, const char* message) {
+  error_at(parser, &parser->previous, message);
+}
+
+static bool check(Parser* parser, TokenType type) {
+  return parser->current.type == type;
+}
+
+static void advance(Parser* parser, Tokenizer* tokenizer) {
+  parser->previous = parser->current;
+  
+  while (true) {
+    parser->current = tokenize(tokenizer);
+    if (parser->current.type != TOKEN_ERROR)
+      break;
+
+    // Whenever the tokenizer encounters an error it produces a token of
+    // type `TOKEN_ERROR` and saves the error message as the lexeme.
+    error_at(parser, &parser->current, parser->current.lexeme);
+  }
+}
+
+static void consume(Parser* parser, Tokenizer* tokenizer, TokenType type, const char* err_message) {
+  if (check(parser, type)) {
+    advance(parser, tokenizer);
+    return;
+  }
+
+  error_at(parser, &parser->current, err_message);
+}
+
+bool compile(VM* vm, const char* source, Program* out_program) {
   Tokenizer tokenizer;
   init_tokenizer(&tokenizer, source);
+  Parser parser;
+  init_parser(&parser);
 
-  int line = -1;
-  while (true) {
-    Token token = tokenize(&tokenizer);
-    bool same_line_as_previous = token.line == line;
-    if (same_line_as_previous)
-      printf("           ");
-    else {
-      printf("line[%4d] ", token.line);
-      line = token.line;
-    }
-    // `token.length` is passed as the argument for '*' (determining how many
-    // characters of `token.start` to display). E.g. tokentype[15] lexeme[else]'.
-    printf("tokentype[%2d] lexeme[%.*s]\n", token.type, token.length, token.lexeme); 
+  advance(&parser, &tokenizer);
 
-    if (token.type == TOKEN_FILE_END)
-      break;
-  }
+  printf("Token: %.*s\n", parser.current.length, parser.current.lexeme);
+
+  return !parser.has_error;
 }

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -1,8 +1,9 @@
 #ifndef CTHUSLY_COMPILER_H
 #define CTHUSLY_COMPILER_H
 
+#include "program.h"
 #include "vm.h"
 
-void compile(VM* vm, const char* source);
+bool compile(VM* vm, const char* source, Program* out_program);
 
 #endif

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -4,6 +4,6 @@
 #include "program.h"
 #include "vm.h"
 
-bool compile(VM* vm, const char* source, Program* out_program);
+bool compile(const char* source, Program* out_program);
 
 #endif

--- a/src/memory.c
+++ b/src/memory.c
@@ -2,16 +2,16 @@
 
 #include "memory.h"
 
-void* reallocate(void* memory, size_t old_size, size_t new_size) {
+void* handle_reallocation(void* memory, size_t old_size, size_t new_size) {
   bool should_free = new_size == 0;
   if (should_free) {
     free(memory);
     return NULL;
   }
 
-  // `realloc()` handles the cases where we should grow (new_size > old_size),
+  // `realloc()` handles the cases where it should grow (new_size > old_size),
   // shrink (new_size < old_size), or allocate (old_size == 0). (It uses the
-  // metadata of the memory block passed to know it's size.)
+  // metadata of the memory block passed to know its size.)
   void* reallocated_memory = realloc(memory, new_size);
   if (reallocated_memory == NULL)
     // Not enough available memory.

--- a/src/memory.h
+++ b/src/memory.h
@@ -9,11 +9,11 @@
   ((capacity) < MIN_GROWTH_THRESHOLD ? MIN_GROWTH_THRESHOLD : (capacity) * GROWTH_FACTOR)
 
 #define GROW_ARRAY(elem_type, array, old_capacity, new_capacity) \
-  (elem_type*)reallocate(array, sizeof(elem_type) * (old_capacity), sizeof(elem_type) * (new_capacity))
+  (elem_type*)handle_reallocation(array, sizeof(elem_type) * (old_capacity), sizeof(elem_type) * (new_capacity))
 
 #define FREE_ARRAY(elem_type, array, capacity) \
-  reallocate(array, sizeof(elem_type) * (capacity), 0)
+  handle_reallocation(array, sizeof(elem_type) * (capacity), 0)
 
-void* reallocate(void* memory, size_t old_capacity, size_t new_capacity);
+void* handle_reallocation(void* memory, size_t old_capacity, size_t new_capacity);
 
 #endif

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -22,7 +22,7 @@ static Token make_token(Tokenizer* tokenizer, TokenType type) {
 
 static Token make_error_token(Tokenizer* tokenizer, const char* message) {
   Token token;
-  token.type = TOKEN_ERROR;
+  token.type = TOKEN_LEXICAL_ERROR;
   token.lexeme = message;
   token.length = (int)(strlen(message));
   token.line = tokenizer->line;

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -50,7 +50,7 @@ typedef enum {
   TOKEN_NEWLINE,
 
   // Errors
-  TOKEN_ERROR,
+  TOKEN_LEXICAL_ERROR,
 } TokenType;
 
 typedef struct {

--- a/src/vm.c
+++ b/src/vm.c
@@ -13,6 +13,8 @@ static void reset_stack(VM* vm) {
 
 void init_vm(VM* vm) {
   reset_stack(vm);
+
+  // TODO
 }
 
 void free_vm(VM* vm) {
@@ -115,7 +117,7 @@ ErrorReport interpret(VM* vm, const char* source) {
   Program program;
   init_program(&program);
 
-  bool has_error = !compile(vm, source, &program);
+  bool has_error = !compile(source, &program);
   if (has_error) {
     free_program(&program);
     return REPORT_COMPILE_ERROR;

--- a/src/vm.c
+++ b/src/vm.c
@@ -25,7 +25,7 @@ void push(VM* vm, ThuslyValue value) {
   *vm->next_stack_top = value;
   vm->next_stack_top++;
 
-  // TODO: Check stack overflow
+  // TODO: Check size before pushing to prevent stack overflow
 }
 
 ThuslyValue pop(VM* vm) {
@@ -112,7 +112,20 @@ static ErrorReport decode_and_execute(VM* vm) {
 }
 
 ErrorReport interpret(VM* vm, const char* source) {
-  compile(vm, source);
+  Program program;
+  init_program(&program);
 
-  return REPORT_NO_ERROR;
+  bool has_error = !compile(vm, source, &program);
+  if (has_error) {
+    free_program(&program);
+    return REPORT_COMPILE_ERROR;
+  }
+
+  vm->program = &program;
+  vm->next_instruction = program.instructions;
+  ErrorReport report = decode_and_execute(vm);
+
+  free_program(&program);
+
+  return report;
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -56,6 +56,7 @@ static inline double op_subtract(double a, double b) {
   return a - b;
 }
 
+// TODO: Perhaps make this a macro
 static inline void binary_op(VM* vm, BinaryOp op) {
   {
     double b = pop(vm);
@@ -67,6 +68,10 @@ static inline void binary_op(VM* vm, BinaryOp op) {
 static ErrorReport decode_and_execute(VM* vm) {
   #define READ_BYTE() (*vm->next_instruction++)
   #define READ_CONSTANT() (vm->program->constant_pool.values[READ_BYTE()])
+
+  #ifdef DEBUG_EXECUTION
+  printf("========== Execution ==========\n");
+  #endif
 
   while (true) {
     #ifdef DEBUG_EXECUTION
@@ -103,7 +108,7 @@ static ErrorReport decode_and_execute(VM* vm) {
       case OP_RETURN: {
         printf("> Result: ");   // Temporary
         print_value(pop(vm));
-        printf("\n");
+        printf("\n\n");
         return REPORT_NO_ERROR;
       }
     }


### PR DESCRIPTION
Adds a combined compiler and parser responsible for parsing the tokens produced by the tokenizer and creating bytecode instructions to be used by the VM.

The following arithmetic expressions can now be parsed:
* Addition (`+`)
* Subtraction (`-`)
* Multiplication (`*`)
* Division (`/`)
* Unary negation (`-`)
* Precedence altering (`()`)

ℹ️ Only `double`s are handled!

This PR enables taking a one-line user input (either from a file or via the repl) and executing it.

| Example input      |  Expected output  | Expected precedence parsing   |
|------------------|-------------------|--------------------------------|
| 1 + 2 * 3 / 4          |  2.5                        | 1 + ((2 * 3) / 4)                             |
| (1 + 2) * 3 / 4       |  2.25                      | ((1 + 2) * 3) / 4                             |
| 1 + -2 - -3            |  2                           | (1 + (-2)) - (-3)                            |

> Note: A debug flag is enabled which also prints the entire bytecode produced by the compiler, as well as the execution steps by the VM including the stack state.