### PR TITLE
Support `text` (string) data type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(cthusly
 	src/exit_code.h
 	src/memory.h
 	src/memory.c
+	src/object.h
 	src/program.h
 	src/program.c
 	src/thusly_value.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(cthusly
 	src/memory.h
 	src/memory.c
 	src/object.h
+	src/object.c
 	src/program.h
 	src/program.c
 	src/thusly_value.h

--- a/README.md
+++ b/README.md
@@ -33,21 +33,20 @@ The design and development are currently on-going and are highly subject to chan
 
 <img src="design/code-snippet.svg" width="600" alt="A snippet of Thusly code.">
 
-Whitespace is semantically insignificant; however, newlines on non-blank lines are significant.
+Whitespace is semantically insignificant except for newline characters on non-blank lines.
 
 ## Milestones
 
 - [x] The terminals in the initial [grammar](design/grammar.txt) can be identified from user input via a multi-line file or single-line REPL input and then tokenized.
   * To try out the tokenizer in isolation and get printouts of the tokens produced use [PR #2](https://github.com/elle-j/thusly/pull/2) (significant newline characters will be printed as newlines).
-- [x] One-line arithmetic expressions using `number` (`double`) can be parsed and compiled.
+- [x] One-line arithmetic expressions using `number` (double) can be executed.
   - [x] Addition (`+`)
   - [x] Subtraction (`-`)
   - [x] Multiplication (`*`)
   - [x] Division (`/`)
   - [x] Unary negation (`-`)
   - [x] Precedence altering (`()`)
-- [x] One-line arithmetic expressions using `number` can be executed.
-- [x] One-line comparison, equality, and logical negation expressions using `number`, `boolean`, and `none` can be executed.
+- [x] One-line comparison, equality, and logical negation expressions using `number`, `boolean`, `none`, and `text` can be executed.
   - [x] Equal to (`=`)
   - [x] Not equal to (`!=`)
   - [x] Greater than (`>`)
@@ -55,23 +54,25 @@ Whitespace is semantically insignificant; however, newlines on non-blank lines a
   - [x] Less than (`<`)
   - [x] Less than or equal to (`<=`)
   - [x] Logical not (`not`)
-- [ ] Support `text` (`string`) data type.
+- [x] Concatenation of `text` literals using `+` can be executed.
 - [ ] Support variable declarations and assignments.
 - [ ] TODO (more milestones will be added here)
 
 ### Implemented Functionality
 
-This section is for briefly demonstrating implemented functionality and what to expect when [running your code](#getting-started).
+This section is for briefly demonstrating implemented functionality thus far and expected behavior when [running your code](#getting-started).
 
 By inputing a **one-line expression** from either a file or via the REPL, the VM will interpret it and output the result.
 
-| Example input            | Expected output | Expected precedence parsing   |
-|--------------------------|-----------------|-------------------------------|
-| 1 + 2 * 3 / 4            | 2.5             | 1 + ((2 * 3) / 4)             |
-| (1 + 2) * 3 / 4          | 2.25            | ((1 + 2) * 3) / 4             |
-| 1 + -2 - -3              | 2               | (1 + (-2)) - (-3)             |
-| 1 > 2 = 3 > 4            | true            | (1 > 2) = (3 > 4)             |
-| false != not(1 + 2 >= 3) | false           | false != (not((1 + 2) >= 3))  |
+| Example input              | Expected output | Expected precedence parsing   |
+|----------------------------|-----------------|-------------------------------|
+| 1 + 2 * 3 / 4              | 2.5             | 1 + ((2 * 3) / 4)             |
+| (1 + 2) * 3 / 4            | 2.25            | ((1 + 2) * 3) / 4             |
+| 1 + -2 - -3                | 2               | (1 + (-2)) - (-3)             |
+| 1 > 2 = 3 > 4              | true            | (1 > 2) = (3 > 4)             |
+| false != not(1 + 2 >= 3)   | false           | false != (not((1 + 2) >= 3))  |
+| "he" + "llo" = "hello"     | true            | ("he" + "llo") = "hello"      |
+| "keep " + "on " + "coding" | keep on coding  | ("keep " + "on ") + "coding"  |
 
 > Note: A debug flag is enabled which also prints the entire bytecode produced by the compiler, as well as the execution steps by the VM including its stack state.
 
@@ -80,7 +81,7 @@ By inputing a **one-line expression** from either a file or via the REPL, the VM
 ### Prerequisites
 
 * A C compiler (e.g. Clang or GCC)
-* [CMake](https://cmake.org/) version 3.20 or higher
+* [CMake](https://cmake.org/) version 3.20 or later
 
 ### Building the Project
 
@@ -90,7 +91,8 @@ Run the below command to make Thusly come to life. It will create a top-level `b
 ./build.sh
 ```
 
-> If permission is denied, first add executable permission to the build script by running `chmod +x build.sh`.
+> If permission is denied, first add executable permission to the build script by running:
+> `chmod +x build.sh`.
 
 ### Running Code
 
@@ -98,7 +100,7 @@ Once you have [built](#building-the-project) the project you can go ahead and fe
 
 **Interpret code from a file:**
 ```sh
-./bin/cthusly path/to/file
+./bin/cthusly path/to/your/file
 ```
 
 **Start the REPL (interactive prompt):**

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -4,6 +4,6 @@
 #include "program.h"
 #include "vm.h"
 
-bool compile(const char* source, Program* out_program);
+bool compile(Environment* environment, const char* source, Program* out_program);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -86,5 +86,5 @@ int main(int argc, const char* argv[]) {
 
   free_vm(&vm);
 
-  return 1;
+  return EXIT_SUCCESS;
 }

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 
 #include "memory.h"
+#include "object.h"
 
 void* handle_reallocation(void* memory, size_t old_size, size_t new_size) {
   bool should_free = new_size == 0;
@@ -18,4 +19,24 @@ void* handle_reallocation(void* memory, size_t old_size, size_t new_size) {
     exit(1);
 
   return reallocated_memory;
+}
+
+static void free_object(Object* object) {
+  switch (object->type) {
+    case OBJECT_TYPE_TEXT: {
+      TextObject* text = (TextObject*)object;
+      FREE_ARRAY(char, text->chars, text->length + 1);
+      FREE(TextObject, object);
+      break;
+    }
+  }
+}
+
+void free_objects(Environment* environment) {
+  Object* current = environment->objects;
+  while (current != NULL) {
+    Object* next = current->next;
+    free_object(current);
+    current = next;
+  }
 }

--- a/src/memory.h
+++ b/src/memory.h
@@ -3,6 +3,8 @@
 
 #include "common.h"
 
+#define ALLOCATE(type, capacity) (type*)handle_reallocation(NULL, 0, sizeof(type) * (capacity))
+
 #define GROWTH_FACTOR 2
 #define MIN_GROWTH_THRESHOLD 10
 #define GROW_CAPACITY(capacity) \

--- a/src/memory.h
+++ b/src/memory.h
@@ -2,6 +2,7 @@
 #define CTHUSLY_MEMORY_H
 
 #include "common.h"
+#include "vm.h"
 
 #define ALLOCATE(type, capacity) (type*)handle_reallocation(NULL, 0, sizeof(type) * (capacity))
 
@@ -16,6 +17,9 @@
 #define FREE_ARRAY(elem_type, array, capacity) \
   handle_reallocation(array, sizeof(elem_type) * (capacity), 0)
 
+#define FREE(type, memory) handle_reallocation(memory, sizeof(type), 0)
+
 void* handle_reallocation(void* memory, size_t old_capacity, size_t new_capacity);
+void free_objects(Environment* environment);
 
 #endif

--- a/src/object.c
+++ b/src/object.c
@@ -5,36 +5,41 @@
 #include "memory.h"
 #include "object.h"
 
-#define ALLOCATE_OBJECT(type, object_type) (type*)allocate_object(sizeof(type), object_type)
+#define ALLOCATE_OBJECT(environment, type, object_type) \
+  (type*)allocate_object(environment, sizeof(type), object_type)
 
-static Object* allocate_object(size_t size, ObjectType object_type) {
+static Object* allocate_object(Environment* environment, size_t size, ObjectType object_type) {
   // `size` needs to come from the argument (rather than using `sizeof(Object)`)
   // since there are different-sized object types.
   Object* object = (Object*)handle_reallocation(NULL, 0, size);
   object->type = object_type;
 
+  // Add the object to the linked list (inserting at the beginning).
+  object->next = environment->objects;
+  environment->objects = object;
+
   return object;
 }
 
-static TextObject* allocate_text_object(char* chars, int length) {
-  TextObject* text = ALLOCATE_OBJECT(TextObject, OBJECT_TYPE_TEXT);
+static TextObject* allocate_text_object(Environment* environment, char* chars, int length) {
+  TextObject* text = ALLOCATE_OBJECT(environment, TextObject, OBJECT_TYPE_TEXT);
   text->chars = chars;
   text->length = length;
 
   return text;
 }
 
-TextObject* claim_c_string(char* chars, int length) {
-  return allocate_text_object(chars, length);
+TextObject* claim_c_string(Environment* environment, char* chars, int length) {
+  return allocate_text_object(environment, chars, length);
 }
 
-TextObject* copy_c_string(const char* chars, int length) {
+TextObject* copy_c_string(Environment* environment, const char* chars, int length) {
   // Allocate +1 for the terminating null byte.
   char* chars_copy = ALLOCATE(char, length + 1);
   memcpy(chars_copy, chars, length);
   chars_copy[length] = '\0';
 
-  return allocate_text_object(chars_copy, length);
+  return allocate_text_object(environment, chars_copy, length);
 }
 
 void print_object(ThuslyValue value) {

--- a/src/object.c
+++ b/src/object.c
@@ -1,0 +1,42 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "memory.h"
+#include "object.h"
+
+#define ALLOCATE_OBJECT(type, object_type) (type*)allocate_object(sizeof(type), object_type)
+
+static Object* allocate_object(size_t size, ObjectType object_type) {
+  // `size` needs to come from the argument (rather than using `sizeof(Object)`)
+  // since there are different-sized object types.
+  Object* object = (Object*)handle_reallocation(NULL, 0, size);
+  object->type = object_type;
+
+  return object;
+}
+
+static TextObject* allocate_text_object(char* chars, int length) {
+  TextObject* text = ALLOCATE_OBJECT(TextObject, OBJECT_TYPE_TEXT);
+  text->chars = chars;
+  text->length = length;
+
+  return text;
+}
+
+TextObject* copy_c_string(const char* chars, int length) {
+  // Allocate +1 for the terminating null byte.
+  char* chars_copy = ALLOCATE(char, length + 1);
+  memcpy(chars_copy, chars, length);
+  chars_copy[length] = '\0';
+
+  return allocate_text_object(chars_copy, length);
+}
+
+void print_object(ThuslyValue value) {
+  switch (GET_OBJECT_TYPE(value)) {
+    case OBJECT_TYPE_TEXT:
+      printf("%s", TO_C_STRING(value));
+      break;
+  }
+}

--- a/src/object.c
+++ b/src/object.c
@@ -24,6 +24,10 @@ static TextObject* allocate_text_object(char* chars, int length) {
   return text;
 }
 
+TextObject* claim_c_string(char* chars, int length) {
+  return allocate_text_object(chars, length);
+}
+
 TextObject* copy_c_string(const char* chars, int length) {
   // Allocate +1 for the terminating null byte.
   char* chars_copy = ALLOCATE(char, length + 1);

--- a/src/object.h
+++ b/src/object.h
@@ -3,6 +3,7 @@
 
 #include "common.h"
 #include "thusly_value.h"
+#include "vm.h"
 
 #define GET_OBJECT_TYPE(thusly_value) (TO_C_OBJECT_PTR(thusly_value)->type)
 #define IS_TEXT(thusly_value)         is_object_type(thusly_value, OBJECT_TYPE_TEXT)
@@ -14,13 +15,16 @@ typedef enum {
   OBJECT_TYPE_TEXT,
 } ObjectType;
 
-/// The common state of all dynamically (heap) allocated values (referred to as objects).
+/// The common state of all dynamically (heap) allocated values (referred to as objects here).
 ///
 /// IMPORTANT: All objects must have this `Object` struct as the first field so that a
 /// pointer to `Object` or the enclosing struct (e.g `TextObject`) always points to the
 /// first field of the `Object` struct. (There is never padding in the beginning of a struct.)
 struct Object {
   ObjectType type;
+  // Pointer to the next heap-allocated object in the (intrusive) linked list.
+  // (The head is pointed to by the VM's `Environment` struct.)
+  struct Object* next;
 };
 
 /// A dynamically allocated text (string) value.
@@ -31,8 +35,8 @@ struct TextObject {
   int length;
 };
 
-TextObject* claim_c_string(char* chars, int length);
-TextObject* copy_c_string(const char* chars, int length);
+TextObject* claim_c_string(Environment* environment, char* chars, int length);
+TextObject* copy_c_string(Environment* environment, const char* chars, int length);
 void print_object(ThuslyValue value);
 
 static inline bool is_object_type(ThuslyValue value, ObjectType type) {

--- a/src/object.h
+++ b/src/object.h
@@ -27,9 +27,12 @@ struct Object {
 struct TextObject {
   // IMPORTANT: This field must be first (see notes in `Object`).
   Object base;
-  int length;
   char* chars;
+  int length;
 };
+
+TextObject* copy_c_string(const char* chars, int length);
+void print_object(ThuslyValue value);
 
 static inline bool is_object_type(ThuslyValue value, ObjectType type) {
   return IS_OBJECT(value) && TO_C_OBJECT_PTR(value)->type == type;

--- a/src/object.h
+++ b/src/object.h
@@ -31,6 +31,7 @@ struct TextObject {
   int length;
 };
 
+TextObject* claim_c_string(char* chars, int length);
 TextObject* copy_c_string(const char* chars, int length);
 void print_object(ThuslyValue value);
 

--- a/src/object.h
+++ b/src/object.h
@@ -1,0 +1,38 @@
+#ifndef CTHUSLY_OBJECT_H
+#define CTHUSLY_OBJECT_H
+
+#include "common.h"
+#include "thusly_value.h"
+
+#define GET_OBJECT_TYPE(thusly_value) (TO_C_OBJECT_PTR(thusly_value)->type)
+#define IS_TEXT(thusly_value)         is_object_type(thusly_value, OBJECT_TYPE_TEXT)
+
+#define TO_TEXT(thusly_value)         ((TextObject*)TO_C_OBJECT_PTR(thusly_value))
+#define TO_C_STRING(thusly_value)     (((TextObject*)TO_C_OBJECT_PTR(thusly_value))->chars)
+
+typedef enum {
+  OBJECT_TYPE_TEXT,
+} ObjectType;
+
+/// The common state of all dynamically (heap) allocated values (referred to as objects).
+///
+/// IMPORTANT: All objects must have this `Object` struct as the first field so that a
+/// pointer to `Object` or the enclosing struct (e.g `TextObject`) always points to the
+/// first field of the `Object` struct. (There is never padding in the beginning of a struct.)
+struct Object {
+  ObjectType type;
+};
+
+/// A dynamically allocated text (string) value.
+struct TextObject {
+  // IMPORTANT: This field must be first (see notes in `Object`).
+  Object base;
+  int length;
+  char* chars;
+};
+
+static inline bool is_object_type(ThuslyValue value, ObjectType type) {
+  return IS_OBJECT(value) && TO_C_OBJECT_PTR(value)->type == type;
+}
+
+#endif

--- a/src/program.c
+++ b/src/program.c
@@ -1,8 +1,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include "memory.h"
 #include "program.h"
-#include "thusly_value.h"
 
 void init_program(Program* program) {
   program->source_lines = NULL;

--- a/src/program.h
+++ b/src/program.h
@@ -2,7 +2,6 @@
 #define CTHUSLY_PROGRAM_H
 
 #include "common.h"
-#include "memory.h"
 #include "thusly_value.h"
 
 typedef enum {

--- a/src/thusly_value.c
+++ b/src/thusly_value.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
+#include <string.h>
 
 #include "memory.h"
+#include "object.h"
 #include "thusly_value.h"
 
 void init_constant_pool(ConstantPool* pool) {
@@ -39,6 +41,11 @@ bool values_are_equal(ThuslyValue a, ThuslyValue b) {
       return true;
     case TYPE_NUMBER:
       return TO_C_DOUBLE(a) == TO_C_DOUBLE(b);
+    case TYPE_OBJECT: {
+      TextObject* textA = TO_TEXT(a);
+      TextObject* textB = TO_TEXT(b);
+      return textA->length == textB->length && memcmp(textA->chars, textB->chars, textA->length) == 0;
+    }
     default:
       // This should not be reachable.
       return false;
@@ -55,6 +62,9 @@ void print_value(ThuslyValue value) {
       break;
     case TYPE_NUMBER:
       printf("%g", TO_C_DOUBLE(value));
+      break;
+    case TYPE_OBJECT:
+      print_object(value);
       break;
   }
 }

--- a/src/thusly_value.h
+++ b/src/thusly_value.h
@@ -11,7 +11,7 @@ typedef enum {
   TYPE_BOOLEAN,
   TYPE_NONE,
   TYPE_NUMBER,
-  // Dynamically allocated type (e.g. `text` (string))
+  // Dynamically (heap) allocated type (e.g. `text` (string))
   TYPE_OBJECT,
 } DataType;
 

--- a/src/thusly_value.h
+++ b/src/thusly_value.h
@@ -3,11 +3,16 @@
 
 #include "common.h"
 
+typedef struct Object Object;
+typedef struct TextObject TextObject;
+
 /// Built-in data types for a ThuslyValue.
 typedef enum {
   TYPE_BOOLEAN,
   TYPE_NONE,
   TYPE_NUMBER,
+  // Dynamically allocated type (e.g. `text` (string))
+  TYPE_OBJECT,
 } DataType;
 
 typedef struct {
@@ -16,19 +21,23 @@ typedef struct {
   union {
     bool c_bool;
     double c_double;
+    Object* c_object_ptr;
   } to;
 } ThuslyValue;
 
-#define IS_BOOLEAN(thusly_value)  ((thusly_value).type == TYPE_BOOLEAN)
-#define IS_NONE(thusly_value)     ((thusly_value).type == TYPE_NONE)
-#define IS_NUMBER(thusly_value)   ((thusly_value).type == TYPE_NUMBER)
+#define IS_BOOLEAN(thusly_value)      ((thusly_value).type == TYPE_BOOLEAN)
+#define IS_NONE(thusly_value)         ((thusly_value).type == TYPE_NONE)
+#define IS_NUMBER(thusly_value)       ((thusly_value).type == TYPE_NUMBER)
+#define IS_OBJECT(thusly_value)       ((thusly_value).type == TYPE_OBJECT)
 
-#define TO_C_BOOL(thusly_value)   ((thusly_value).to.c_bool)
-#define TO_C_DOUBLE(thusly_value) ((thusly_value).to.c_double)
+#define TO_C_BOOL(thusly_value)       ((thusly_value).to.c_bool)
+#define TO_C_DOUBLE(thusly_value)     ((thusly_value).to.c_double)
+#define TO_C_OBJECT_PTR(thusly_value) ((thusly_value).to.c_object_ptr)
 
-#define FROM_C_BOOL(c_value)      ((ThuslyValue){ TYPE_BOOLEAN, { .c_bool = c_value } })
-#define FROM_C_NULL               ((ThuslyValue){ TYPE_NONE, { .c_double = 0 } })
-#define FROM_C_DOUBLE(c_value)    ((ThuslyValue){ TYPE_NUMBER, { .c_double = c_value } })
+#define FROM_C_BOOL(c_value)          ((ThuslyValue){ TYPE_BOOLEAN, { .c_bool = c_value } })
+#define FROM_C_NULL                   ((ThuslyValue){ TYPE_NONE, { .c_double = 0 } })
+#define FROM_C_DOUBLE(c_value)        ((ThuslyValue){ TYPE_NUMBER, { .c_double = c_value } })
+#define FROM_C_OBJECT_PTR(c_ptr)      ((ThuslyValue){ TYPE_OBJECT, { .c_object_ptr = (Object*)c_ptr } })
 
 typedef struct {
   ThuslyValue* values;

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -1,6 +1,5 @@
 #include <string.h>
 
-#include "common.h"
 #include "tokenizer.h"
 
 void init_tokenizer(Tokenizer* tokenizer, const char* source) {

--- a/src/vm.h
+++ b/src/vm.h
@@ -6,11 +6,23 @@
 
 #define STACK_MAX 256
 
+struct VM;
+
+/// Heap data used by the VM.
 typedef struct {
+  struct VM* vm;
+  // Heap-allocated objects (points to the head).
+  Object* objects;
+} Environment;
+
+/// The virtual machine interpreting and executing the instructions in
+/// the compiled program in a sequential order.
+typedef struct VM {
+  Environment environment;
   Program* program;
   byte* next_instruction;
   ThuslyValue stack[STACK_MAX];
-  // When pointing to zeroth element, the stack is empty.
+  // When pointing to the zeroth element, the stack is empty.
   ThuslyValue* next_stack_top;
 } VM;
 


### PR DESCRIPTION
Adds support for the `text` (string) data type and extends the following expressions to handle it:
* Equality
  * Equal to (`=`)
  * Not equal to (`!=`)
* Logical not (`not`)
  * If the operand is *truthy*, it returns `false` otherwise `true`.
  * All `text` literals (including `""`) are truthy.
* Concatenation (`+`)

Only one-line expressions are currently supported, see examples of expected behavior:

| Example input                      | Expected output  | Expected precedence parsing   |
|----------------------------|------------------|--------------------------------|
| "he" + "llo" = "hello"           | true                       | ("he" + "llo") = "hello"               |
| "keep " + "on " + "coding" | keep on coding    | ("keep " + "on ") + "coding"      |
