### PR TITLE
Support modulo (`mod`) operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A general-purpose programming language coming to life through a one-pass compile
 
 - [Language](#language)
     - [Characteristics](#characteristics)
-    - [Early Syntax](#early-syntax)
+    - [Syntax](#syntax)
 - [Milestones](#milestones)
     - [Implemented Functionality](#implemented-functionality)
 - [Getting Started](#getting-started)
@@ -27,9 +27,9 @@ A general-purpose programming language coming to life through a one-pass compile
 * Imperative
 * Garbage collected
 
-### Early Syntax 
+### Syntax
 
-The design and development are currently on-going and are highly subject to change. The following is a subset of the language:
+The development of both the language and the surrounding documentation is currently on-going, but the following is a subset of the language:
 
 <img src="design/code-snippet.svg" width="600" alt="A snippet of Thusly code.">
 
@@ -44,6 +44,7 @@ Whitespace is semantically insignificant except for newline characters on non-bl
   - [x] Subtraction (`-`)
   - [x] Multiplication (`*`)
   - [x] Division (`/`)
+  - [x] Modulo (`mod`)
   - [x] Unary negation (`-`)
   - [x] Precedence altering (`()`)
 - [x] One-line comparison, equality, and logical negation expressions using `number`, `boolean`, `text` (string), and `none` can be executed.
@@ -78,11 +79,11 @@ By inputing a **one-line expression** from either a file or via the REPL, the VM
 
 **Table 2: Invalid user input**
 
-| Example invalid input      | Error type   | Expected error reason                        |
-|----------------------------|--------------|----------------------------------------------|
-| "one" + 2                  | Runtime      | `+` operates on `number` only or `text` only |
-| "one" < 2                  | Runtime      | `<` operates on `number` only                |
-| !true                      | Compile      | `!` is only allowed in `!=` (use `not`)      |
+| Example input | Error type | Expected error reason                           |
+|---------------|------------|-------------------------------------------------|
+| "one" + 2     | Runtime    | `+` operates on `number` only or `text` only    |
+| "one" < 2     | Runtime    | `<` operates on `number` only                   |
+| !true         | Compile    | `!` is only allowed in `!=` (use `not`)         |
 
 ## Getting Started
 

--- a/design/grammar.txt
+++ b/design/grammar.txt
@@ -80,7 +80,7 @@ term:
 	| factor ( ( "+" | "-" ) factor )*
 
 factor:
-	| unary ( ( "*" | "/" ) unary )*
+	| unary ( ( "*" | "/" | "mod" ) unary )*
 
 unary:
 	| ( "not" | "-" ) unary

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -83,6 +83,7 @@ static ParseRule rules[] = {
   // Reserved keywords
   [TOKEN_AND]                   = { NULL, NULL, PRECEDENCE_IGNORE },
   [TOKEN_FALSE]                 = { parse_boolean, NULL, PRECEDENCE_IGNORE },
+  [TOKEN_MOD]                   = { NULL, parse_binary, PRECEDENCE_FACTOR },
   [TOKEN_NONE]                  = { parse_none, NULL, PRECEDENCE_IGNORE },
   [TOKEN_NOT]                   = { parse_unary, NULL, PRECEDENCE_IGNORE },
   [TOKEN_OR]                    = { NULL, NULL, PRECEDENCE_IGNORE },
@@ -265,6 +266,9 @@ static void parse_binary(Parser* parser) {
       break;
     case TOKEN_SLASH:
       write_instruction(parser, OP_DIVIDE);
+      break;
+    case TOKEN_MOD:
+      write_instruction(parser, OP_MODULO);
       break;
     default:
       // This should not be reachable.

--- a/src/debug.c
+++ b/src/debug.c
@@ -75,12 +75,14 @@ int disassemble_instruction(Program* program, int offset) {
       return print_opcode("OP_LESS_THAN_EQUALS", offset);
     case OP_ADD:
       return print_opcode("OP_ADD", offset);
-    case OP_DIVIDE:
-      return print_opcode("OP_DIVIDE", offset);
-    case OP_MULTIPLY:
-      return print_opcode("OP_MULTIPLY", offset);
     case OP_SUBTRACT:
       return print_opcode("OP_SUBTRACT", offset);
+    case OP_MULTIPLY:
+      return print_opcode("OP_MULTIPLY", offset);
+    case OP_DIVIDE:
+      return print_opcode("OP_DIVIDE", offset);
+    case OP_MODULO:
+      return print_opcode("OP_MODULO", offset);
     case OP_NEGATE:
       return print_opcode("OP_NEGATE", offset);
     case OP_NOT:

--- a/src/program.h
+++ b/src/program.h
@@ -7,6 +7,7 @@
 typedef enum {
   OP_ADD,
   OP_CONSTANT,
+  // Dedicated operations for common constants.
   OP_CONSTANT_FALSE,
   OP_CONSTANT_NONE,
   OP_CONSTANT_TRUE,
@@ -16,6 +17,7 @@ typedef enum {
   OP_GREATER_THAN_EQUALS,
   OP_LESS_THAN,
   OP_LESS_THAN_EQUALS,
+  OP_MODULO,
   OP_MULTIPLY,
   OP_NEGATE,
   OP_NOT,

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -162,6 +162,8 @@ static TokenType get_keyword_or_identifier_type(Tokenizer* tokenizer) {
       return search_keyword(tokenizer, 1, "nd", 2, TOKEN_AND);
     case 'f':
       return search_keyword(tokenizer, 1, "alse", 4, TOKEN_FALSE);
+    case 'm':
+      return search_keyword(tokenizer, 1, "od", 2, TOKEN_MOD);
     case 'n':
       if (lexeme_length > 2) {
         switch (tokenizer->start[1]) {
@@ -234,7 +236,7 @@ Token tokenize(Tokenizer* tokenizer) {
     case '!':
       if (match(tokenizer, '='))
         return make_token(tokenizer, TOKEN_EXCLAMATION_EQUALS);
-      return make_error_token(tokenizer, "You have included an illegal character: ! (This character is only allowed in !=)");
+      return make_error_token(tokenizer, "You have included an illegal character: ! (This character is only allowed in `!=`. Did you mean `not`?)");
     case '<':
       return match(tokenizer, '=')
         ? make_token(tokenizer, TOKEN_LESS_THAN_EQUALS)

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -31,6 +31,7 @@ typedef enum {
   TOKEN_FALSE,
   // TOKEN_FUN,
   // TOKEN_IF,
+  TOKEN_MOD,
   TOKEN_NONE,
   TOKEN_NOT,
   TOKEN_OR,

--- a/src/vm.c
+++ b/src/vm.c
@@ -8,7 +8,6 @@
 #include "debug.h"
 #include "gc_object.h"
 #include "memory.h"
-#include "program.h"
 #include "vm.h"
 
 static void reset_stack(VM* vm) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -7,6 +8,7 @@
 #include "debug.h"
 #include "gc_object.h"
 #include "memory.h"
+#include "program.h"
 #include "vm.h"
 
 static void reset_stack(VM* vm) {
@@ -124,7 +126,6 @@ static ErrorReport decode_and_execute(VM* vm) {
         push(vm, constant);
         break;
       }
-      // TODO: Add comment about providing designated instructions for certain constants.
       case OP_CONSTANT_FALSE:
         push(vm, FROM_C_BOOL(false));
         break;
@@ -172,15 +173,27 @@ static ErrorReport decode_and_execute(VM* vm) {
         }
         break;
       }
-      case OP_DIVIDE:
-        DO_BINARY_OP(FROM_C_DOUBLE, /);
+      case OP_SUBTRACT:
+        DO_BINARY_OP(FROM_C_DOUBLE, -);
         break;
       case OP_MULTIPLY:
         DO_BINARY_OP(FROM_C_DOUBLE, *);
         break;
-      case OP_SUBTRACT:
-        DO_BINARY_OP(FROM_C_DOUBLE, -);
+      case OP_DIVIDE:
+        DO_BINARY_OP(FROM_C_DOUBLE, /);
         break;
+        // TODO: Handle division by 0
+      case OP_MODULO: {
+        if (!IS_NUMBER(peek(vm, 0)) || !IS_NUMBER(peek(vm, 1))) {
+          error(vm, "Modulo can only be performed on numbers.");
+          return REPORT_RUNTIME_ERROR;
+        }
+        double b = TO_C_DOUBLE(pop(vm));
+        double a = TO_C_DOUBLE(pop(vm));
+        push(vm, FROM_C_DOUBLE(fmod(a, b)));
+        break;
+        // TODO: Handle division by 0
+      }
       case OP_NEGATE:
         // Peek at the stack rather than pop here in case there is garbage
         // collection before the value is pushed onto the stack again.


### PR DESCRIPTION
Adds support for the following arithmetic operator:
* Modulo (`mod`)
  * Only `number` operands are allowed.

The current implementation only supports one-line expressions, see examples of expected behavior:

| Example input               | Expected output  | Expected precedence parsing   |
|------------------------|------------------|--------------------------------|
| 4 mod 3 / 2                    | 0.5                         | (4 mod 3) / 2                               |
| 1 + 2 * 3 mod 4              | 3                            | 1 + ((2 * 3) mod 4)                     |

> Results behave as [fmod](https://en.cppreference.com/w/c/numeric/math/fmod) in this PR, including division by zero.