### PR TITLE
Set up support for statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A general-purpose programming language coming to life through a one-pass compile
     - [Characteristics](#characteristics)
     - [Syntax](#syntax)
 - [Milestones](#milestones)
+    - [Milestone 1 - Expressions](#milestone-1-evaluate-arithmetic-comparison-and-equality-expressions)
+    - [Milestone 2 - Statements](#milestone-2-execute-variable-control-flow-and-function-statements)
     - [Implemented Functionality](#implemented-functionality)
 - [Getting Started](#getting-started)
     - [Prerequisites](#prerequisites)
@@ -37,6 +39,8 @@ Whitespace is semantically insignificant except for newline characters on non-bl
 
 ## Milestones
 
+### Milestone 1: Evaluate arithmetic, comparison, and equality expressions
+
 - [x] The terminals in the initial [grammar](design/grammar.txt) can be identified from user input via a multi-line file or single-line REPL input and then tokenized.
   * To try out the tokenizer in isolation and get printouts of the tokens produced use [PR #2](https://github.com/elle-j/thusly/pull/2) (significant newline characters will be printed as newlines).
 - [x] Arithmetic expressions using `number` (double) can be evaluated.
@@ -57,6 +61,10 @@ Whitespace is semantically insignificant except for newline characters on non-bl
   - [x] Not equal to (`!=`)
   - [x] Logical not (`not`)
 - [x] Concatenation of `text` literals using `+` can be evaluated.
+
+### Milestone 2: Execute variable, control flow, and function statements
+
+- [x] Temporary `@out` statement can be executed.
 - [ ] Support variable declarations and assignments.
 - [ ] TODO (more milestones will be added here)
 
@@ -66,7 +74,7 @@ This section is for briefly demonstrating implemented functionality thus far and
 
 By inputing a **one-line expression** from either a file or via the REPL, the VM will interpret it and output the result.
 
-**Table 1: Valid user input**
+**Table 1: Valid user input (expressions)**
 
 | Example input              | Expected output | Expected precedence parsing   |
 |----------------------------|-----------------|-------------------------------|
@@ -78,7 +86,13 @@ By inputing a **one-line expression** from either a file or via the REPL, the VM
 | "he" + "llo" = "hello"     | true            | ("he" + "llo") = "hello"      |
 | "keep " + "on " + "coding" | keep on coding  | ("keep " + "on ") + "coding"  |
 
-**Table 2: Invalid user input**
+**Table 2: Valid user input (statements)**
+
+| Example input              | Expected output | Comment                       |
+|----------------------------|-----------------|-------------------------------|
+| @out "he" + "llo"          | "hello"         | Temporary statement until the built-in function is implemented |
+
+**Table 3: Invalid user input**
 
 | Example input | Error type | Expected error reason                           |
 |---------------|------------|-------------------------------------------------|
@@ -121,11 +135,13 @@ Usage: ./bin/cthusly [options] [path]
 ```
 
 **Interpret code from a file:**
+
 ```sh
 ./bin/cthusly path/to/your/file
 ```
 
 **Start the REPL (interactive prompt):**
+
 ```sh
 ./bin/cthusly
 ```
@@ -135,9 +151,9 @@ Example:
 ```
 $ ./bin/cthusly
 
-> "he" + "llo" = "hello"
+> @out "he" + "llo" = "hello"
 true
-> (1 + 2) * 3 / 4
+> @out (1 + 2) * 3 / 4
 2.25
 > 
 ```

--- a/design/grammar.txt
+++ b/design/grammar.txt
@@ -45,10 +45,14 @@ STATEMENT RULES
 
 statement:
 	| expressionStatement
+	| outStatement			# Temporary until built-in function
 	| varStatement
 
 varStatement:
 	| "var" IDENTIFIER ":" expression NEWLINE
+
+outStatement:
+	| "@out" expression NEWLINE
 
 expressionStatement:
 	| expression NEWLINE
@@ -104,6 +108,9 @@ LEXICAL RULES
 
 IDENTIFIER:
 	| ALPHA ( ALPHA | DIGIT )*
+
+NATIVE_IDENTIFIER:
+	| "@" IDENTIFIER
 
 NUMBER:
 	| DIGIT+ ( "." DIGIT+ )?

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -53,6 +53,7 @@ typedef struct {
 } ParseRule;
 
 static void parse_statement(Parser* parser);
+static void parse_expression_statement(Parser* parser);
 static void parse_out_statement(Parser* parser);
 static void parse_expression(Parser* parser);
 static void parse_binary(Parser* parser);
@@ -222,9 +223,16 @@ static void write_return_instruction(Parser* parser) {
 }
 
 static void parse_statement(Parser* parser) {
-  if (match(parser, TOKEN_OUT)) {
+  if (match(parser, TOKEN_OUT))
     parse_out_statement(parser);
-  }
+  else
+    parse_expression_statement(parser);
+}
+
+static void parse_expression_statement(Parser* parser) {
+  parse_expression(parser);
+  consume_newline(parser);
+  write_instruction(parser, OP_POP);
 }
 
 static void parse_out_statement(Parser* parser) {

--- a/src/debug.c
+++ b/src/debug.c
@@ -87,6 +87,8 @@ int disassemble_instruction(Program* program, int offset) {
       return print_opcode("OP_NEGATE", offset);
     case OP_NOT:
       return print_opcode("OP_NOT", offset);
+    case OP_OUT:
+      return print_opcode("OP_OUT", offset);
     case OP_RETURN:
       return print_opcode("OP_RETURN", offset);
     default:

--- a/src/debug.c
+++ b/src/debug.c
@@ -53,6 +53,8 @@ int disassemble_instruction(Program* program, int offset) {
 
   byte instruction = program->instructions[offset];
   switch (instruction) {
+    case OP_POP:
+      return print_opcode("OP_POP", offset);
     case OP_CONSTANT:
       return print_constant("OP_CONSTANT", program, offset);
     case OP_CONSTANT_FALSE:

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@ static void run_repl() {
   while (true) {
     printf("> ");
     // Only handling single-line inputs.
+    // TODO: Provide alternative grammar for handling NEWLINE and single inputs.
     if (!fgets(line, sizeof(line), stdin)) {
       printf("\n");
       break;

--- a/src/program.h
+++ b/src/program.h
@@ -11,6 +11,7 @@ typedef enum {
   OP_CONSTANT_FALSE,
   OP_CONSTANT_NONE,
   OP_CONSTANT_TRUE,
+  // ----
   OP_DIVIDE,
   OP_EQUALS,
   OP_GREATER_THAN,
@@ -22,6 +23,7 @@ typedef enum {
   OP_NEGATE,
   OP_NOT,
   OP_NOT_EQUALS,
+  OP_OUT,
   OP_RETURN,
   OP_SUBTRACT,
 } Opcode;

--- a/src/program.h
+++ b/src/program.h
@@ -24,6 +24,7 @@ typedef enum {
   OP_NOT,
   OP_NOT_EQUALS,
   OP_OUT,
+  OP_POP,
   OP_RETURN,
   OP_SUBTRACT,
 } Opcode;

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -158,6 +158,8 @@ static TokenType get_keyword_or_identifier_type(Tokenizer* tokenizer) {
   // Using a trie to check if it is one of the keywords.
   int lexeme_length = tokenizer->current - tokenizer->start;
   switch (tokenizer->start[0]) {
+    case '@':
+      return search_keyword(tokenizer, 1, "out", 3, TOKEN_OUT);
     case 'a':
       return search_keyword(tokenizer, 1, "nd", 2, TOKEN_AND);
     case 'f':
@@ -179,8 +181,6 @@ static TokenType get_keyword_or_identifier_type(Tokenizer* tokenizer) {
       break;
     case 'o':
       return search_keyword(tokenizer, 1, "r", 1, TOKEN_OR);
-    case 'p':
-      return search_keyword(tokenizer, 1, "rint", 4, TOKEN_PRINT);
     case 't':
       return search_keyword(tokenizer, 1, "rue", 3, TOKEN_TRUE);
     case 'v':
@@ -247,6 +247,13 @@ Token tokenize(Tokenizer* tokenizer) {
         : make_token(tokenizer, TOKEN_GREATER_THAN);
     case '"':
       return consume_text(tokenizer);
+    case '@': {
+      Token token = consume_keyword_or_identifier(tokenizer);
+      // Temporary until built-in functions are supported.
+      return token.type == TOKEN_OUT
+        ? token
+        : make_error_token(tokenizer, "'@' is only allowed in names of the built-in functionality.");
+    }
     default:
       if (is_alpha(character))
         return consume_keyword_or_identifier(tokenizer);

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -35,7 +35,7 @@ typedef enum {
   TOKEN_NONE,
   TOKEN_NOT,
   TOKEN_OR,
-  TOKEN_PRINT,    // Temporary until built-in function exists
+  TOKEN_OUT,    // Temporary until built-in function exists
   // TOKEN_RETURN,
   TOKEN_TRUE,
   TOKEN_VAR,

--- a/src/vm.c
+++ b/src/vm.c
@@ -207,9 +207,11 @@ static ErrorReport decode_and_execute(VM* vm) {
       case OP_NOT:
         push(vm, FROM_C_BOOL(!is_truthy(pop(vm))));
         break;
-      case OP_RETURN: {
+      case OP_OUT:
         print_value(pop(vm));
         printf("\n");
+        break;
+      case OP_RETURN: {
         return REPORT_NO_ERROR;
       }
     }

--- a/src/vm.c
+++ b/src/vm.c
@@ -122,6 +122,9 @@ static ErrorReport decode_and_execute(VM* vm) {
 
     byte instruction = READ_BYTE();
     switch (instruction) {
+      case OP_POP:
+        pop(vm);
+        break;
       case OP_CONSTANT: {
         ThuslyValue constant = READ_CONSTANT();
         push(vm, constant);

--- a/src/vm.c
+++ b/src/vm.c
@@ -229,8 +229,8 @@ ErrorReport interpret(VM* vm, const char* source) {
   Program program;
   program_init(&program);
 
-  bool has_error = !compile(&vm->environment, source, &program);
-  if (has_error) {
+  bool saw_error = !compile(&vm->environment, source, &program);
+  if (saw_error) {
     program_free(&program);
     return REPORT_COMPILE_ERROR;
   }


### PR DESCRIPTION
Sets up support for implementing upcoming statements, and adds support for a temporary `@out` statement (until the built-in `@out()` function has been implemented):
* `@out <expression> NEWLINE`

| Example input               | Expected output  |
|------------------------|------------------|
| @out "he" + "llo"          | "hello"                   |
