### PR TITLE
Optimize discarding scope via new `POPN` opcode

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -11,6 +11,14 @@ static int print_opcode(const char* op_name, int offset) {
   return offset + 1;
 }
 
+static int print_pop_n(const char* op_name, Program* program, int offset) {
+  byte number = program->instructions[offset + 1];
+  // See `compiler.discard_scope()` for comments regarding `number + 1`.
+  printf("op[%s] count[%d]\n", op_name, number + 1);
+
+  return offset + 2;
+}
+
 static int print_constant(const char* op_name, Program* program, int offset) {
   byte constant_index = program->instructions[offset + 1]; 
   // printf("op[%-16s] index[%4d] value[", op_name, constant_index);
@@ -66,6 +74,8 @@ int disassemble_instruction(Program* program, int offset) {
   switch (instruction) {
     case OP_POP:
       return print_opcode("OP_POP", offset);
+    case OP_POPN:
+      return print_pop_n("OP_POPN", program, offset);
     case OP_GET_VAR:
       return print_variable("OP_GET_VAR", program, offset);
     case OP_SET_VAR:

--- a/src/program.h
+++ b/src/program.h
@@ -26,6 +26,7 @@ typedef enum {
   OP_NOT_EQUALS,
   OP_OUT,
   OP_POP,
+  OP_POPN,
   OP_RETURN,
   OP_SET_VAR,
   OP_SUBTRACT,

--- a/src/vm.c
+++ b/src/vm.c
@@ -68,6 +68,12 @@ static ThuslyValue pop(VM* vm) {
   // TODO: Check empty
 }
 
+static ThuslyValue pop_n(VM* vm, int n) {
+  vm->next_stack_top -= n;
+
+  return *vm->next_stack_top;
+}
+
 static ThuslyValue peek(VM* vm, int offset) {
   // The current stack top is 1 before next_stack_top. Thus, if the offset passed
   // is 0, this should peek at next_stack_top[-1].
@@ -128,6 +134,14 @@ static ErrorReport decode_and_execute(VM* vm) {
       case OP_POP:
         pop(vm);
         break;
+      case OP_POPN: {
+        byte n = READ_BYTE();
+        // `N` in `POPN` is treated as "the number to pop minus 1" in order to allow
+        // popping the maximum number of variables supported on the stack (UINT8_MAX + 1,
+        // i.e. 256). Therefore, it is incremented by 1 here.
+        pop_n(vm, n + 1);
+        break;
+      }
       case OP_GET_VAR: {
         byte slot = READ_BYTE();
         // Since this is a stack-based VM, instructions will rely on values

--- a/src/vm.h
+++ b/src/vm.h
@@ -5,7 +5,7 @@
 #include "table.h"
 #include "thusly_value.h"
 
-#define STACK_MAX 256
+#define STACK_MAX (UINT8_MAX + 1)
 
 struct VM;
 


### PR DESCRIPTION
Adds a `POPN` opcode used when discarding more than 1 variable when exiting a block. Previously, `POP` was used for each local variable.