### PR TITLE
Implement `if-else` statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,19 @@ Whitespace is semantically insignificant except for newline characters on non-bl
       <statements>
     end
     ```
-- [ ] Can execute control flow
-- [ ] Can call functions
+- [ ] Control flow statements can be executed.
+  - [ ] Selection
+    - [x] `if`
+    - [ ] `elseif`
+    - [x] `else`
+  - [ ] Loops
+    - [ ] Bounded (`foreach`)
+    - [ ] Unbounded (`while`)
+- [ ] Logical operators can be evaluated.
+  - [ ] Conjunction (`and`)
+  - [ ] Disjunction (`or`)
+- [ ] Range comparison expression (`in`) can be evaluated.
+- [ ] Functions can be defined and invoked.
 - [ ] TODO (more milestones will be added here)
 
 ### Implemented Functionality
@@ -100,9 +111,10 @@ By inputting code from either a file or via the REPL, the VM will interpret it a
 
 | Example input              | Expected output |
 |----------------------------|-----------------|
-| `var first: "Jane"`<br>`var last: "Doe"`<br>`var full: first + " " + last`<br>`@out full`<br>          | Jane Doe         |
-| `var x: 1`<br>`var y: 2`<br>`var z: x: y`<br>`@out x`<br>`@out z`<br>          | 2<br>2         |
-| `var x: "global"`<br>`@out x`<br><br>`block`<br>`  x: "changed global"`<br><br>`  var x: "local"`<br>`  @out x`<br>`end`<br><br>`@out x`<br>          | global<br>local<br>changed global         |
+| `var first: "Jane"`<br>`var last: "Doe"`<br>`var full: first + " " + last`<br>`@out full` | Jane Doe         |
+| `var x: 1`<br>`var y: 2`<br>`var z: x: y`<br>`@out x`<br>`@out z` | 2<br>2         |
+| `var x: "global"`<br>`@out x`<br><br>`block`<br>`  x: "changed global"`<br><br>`  var x: "local"`<br>`  @out x`<br>`end`<br><br>`@out x` | global<br>local<br>changed global         |
+| `var x: 0`<br>`if x < 10`<br>`  @out "in if"`<br>`else`<br>`  @out "in else"`<br>`end` | in if   |
 
 **Table 3: Invalid user input**
 

--- a/design/grammar.txt
+++ b/design/grammar.txt
@@ -46,6 +46,7 @@ STATEMENT RULES
 statement:
 	| blockStatement
 	| expressionStatement
+	| ifStatement
 	| outStatement			# Temporary until built-in function
 	| varStatement
 
@@ -55,11 +56,21 @@ blockStatement:
 expressionStatement:
 	| expression NEWLINE
 
+ifStatement:
+	| "if" expression danglingBlock ( "elseif" expression danglingBlock )* ( "else" danglingBlock )? "end" NEWLINE
+
 outStatement:
 	| "@out" expression NEWLINE
 
 varStatement:
 	| "var" IDENTIFIER ":" expression NEWLINE
+
+------------------------------------------------------------------
+HELPER RULES
+------------------------------------------------------------------
+
+danglingBlock:
+	| NEWLINE statement+
 
 ------------------------------------------------------------------
 EXPRESSION RULES

--- a/design/grammar.txt
+++ b/design/grammar.txt
@@ -57,7 +57,7 @@ expressionStatement:
 	| expression NEWLINE
 
 ifStatement:
-	| "if" expression danglingBlock ( "elseif" expression danglingBlock )* ( "else" danglingBlock )? "end" NEWLINE
+	| "if" expression danglingBlock ( "else" danglingBlock )? "end" NEWLINE
 
 outStatement:
 	| "@out" expression NEWLINE

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -119,6 +119,7 @@ static ParseRule rules[] = {
   [TOKEN_AND]                   = { NULL, NULL, PRECEDENCE_IGNORE },
   [TOKEN_BLOCK]                 = { NULL, NULL, PRECEDENCE_IGNORE },
   [TOKEN_END]                   = { NULL, NULL, PRECEDENCE_IGNORE },
+  [TOKEN_ELSE]                  = { NULL, NULL, PRECEDENCE_IGNORE },
   [TOKEN_FALSE]                 = { parse_boolean, NULL, PRECEDENCE_IGNORE },
   [TOKEN_IF]                    = { NULL, NULL, PRECEDENCE_IGNORE },
   [TOKEN_MOD]                   = { NULL, parse_binary, PRECEDENCE_FACTOR },

--- a/src/debug.c
+++ b/src/debug.c
@@ -39,6 +39,13 @@ static int print_variable(const char* op_name, Program* program, int offset) {
   return offset + 2;
 }
 
+static int print_jump(const char* op_name, Program* program, int sign, int offset) {
+  uint16_t jump_offset = (uint16_t)((program->instructions[offset + 1] << 8) | program->instructions[offset + 2]);
+  printf("op[%s] from[%d] to[%d]\n", op_name, offset, offset + 3 + sign * jump_offset);
+
+  return offset + 3;
+}
+
 void disassemble_stack(VM* vm) {
   printf("                        stack[");
   for (ThuslyValue* stack_elem_ptr = vm->stack; stack_elem_ptr < vm->next_stack_top; stack_elem_ptr++) {
@@ -116,6 +123,10 @@ int disassemble_instruction(Program* program, int offset) {
       return print_opcode("OP_NOT", offset);
     case OP_OUT:
       return print_opcode("OP_OUT", offset);
+    case OP_JUMP_FWD:
+      return print_jump("OP_JUMP_FWD", program, 1, offset);
+    case OP_JUMP_FWD_IF_FALSE:
+      return print_jump("OP_JUMP_FWD_IF_FALSE", program, 1, offset);
     case OP_RETURN:
       return print_opcode("OP_RETURN", offset);
     default:

--- a/src/program.c
+++ b/src/program.c
@@ -68,6 +68,10 @@ void program_write(Program* program, byte instruction, int source_line) {
   program->count++;
 }
 
+void program_overwrite(Program* program, int offset, byte updated_instruction) {
+  program->instructions[offset] = updated_instruction;
+}
+
 int program_add_constant(Program* program, ThuslyValue value) {
   constant_pool_add(&program->constant_pool, value);
 

--- a/src/program.h
+++ b/src/program.h
@@ -17,6 +17,8 @@ typedef enum {
   OP_GET_VAR,
   OP_GREATER_THAN,
   OP_GREATER_THAN_EQUALS,
+  OP_JUMP_FWD,
+  OP_JUMP_FWD_IF_FALSE,
   OP_LESS_THAN,
   OP_LESS_THAN_EQUALS,
   OP_MODULO,
@@ -49,6 +51,7 @@ typedef struct {
 void program_init(Program* program);
 void program_free(Program* program);
 void program_write(Program* program, byte instruction, int source_line);
+void program_overwrite(Program* program, int offset, byte updated_instruction);
 int program_add_constant(Program* program, ThuslyValue value);
 
 #endif

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -177,7 +177,15 @@ static TokenType get_keyword_or_identifier_type(Tokenizer* tokenizer) {
     case 'b':
       return search_keyword(tokenizer, 1, "lock", 4, TOKEN_BLOCK);
     case 'e':
-      return search_keyword(tokenizer, 1, "nd", 2, TOKEN_END);
+      if (lexeme_length > 1) {
+        switch (tokenizer->start[1]) {
+          case 'l':
+            return search_keyword(tokenizer, 2, "se", 2, TOKEN_ELSE);
+          case 'n':
+            return search_keyword(tokenizer, 2, "d", 1, TOKEN_END);
+        }
+      }
+      break;
     case 'f':
       return search_keyword(tokenizer, 1, "alse", 4, TOKEN_FALSE);
     case 'i':

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -180,6 +180,8 @@ static TokenType get_keyword_or_identifier_type(Tokenizer* tokenizer) {
       return search_keyword(tokenizer, 1, "nd", 2, TOKEN_END);
     case 'f':
       return search_keyword(tokenizer, 1, "alse", 4, TOKEN_FALSE);
+    case 'i':
+      return search_keyword(tokenizer, 1, "f", 1, TOKEN_IF);
     case 'm':
       return search_keyword(tokenizer, 1, "od", 2, TOKEN_MOD);
     case 'n':

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -31,7 +31,7 @@ typedef enum {
   TOKEN_END,
   TOKEN_FALSE,
   // TOKEN_FUN,
-  // TOKEN_IF,
+  TOKEN_IF,
   TOKEN_MOD,
   TOKEN_NONE,
   TOKEN_NOT,

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -27,7 +27,7 @@ typedef enum {
   TOKEN_AND,
   TOKEN_BLOCK,
   // TOKEN_CONST,
-  // TOKEN_ELSE,
+  TOKEN_ELSE,
   TOKEN_END,
   TOKEN_FALSE,
   // TOKEN_FUN,


### PR DESCRIPTION
Adds support for the following control flow statements:
- Selection
  - [x] `if`
  - [x] `else`

The `if` branch is taken if its condition is *truthy*. All Thusly values are truthy except: `none` and `false`. (The number `0` is thereby also considered truthy.)

| Example valid input              | Expected output |
|----------------------------|-----------------|
| `var x: 0`<br>`if x < 10`<br>`  @out "in if"`<br>`else`<br>`  @out "in else"`<br>`end` | in if   |

> **`@out`**
> The temporary `@out` statement in the example is used until the built-in function has been implemented.