### PR TITLE
Extend `while` statement with optional expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The development of both the language and the surrounding documentation is curren
     <summary>Example 1</summary>
 
     ```
-    // `step` value is implicitly 1
+    // `<change>` expression is implicitly 1
     foreach value in 0..10
       @out value
     end
@@ -166,7 +166,7 @@ The development of both the language and the surrounding documentation is curren
 
     - [x] Unbounded (`while`)
     ```
-    while <condition>
+    while <condition> { <change> }
       <statements>
     end
     ```
@@ -174,10 +174,10 @@ The development of both the language and the surrounding documentation is curren
     <summary>Example</summary>
 
     ```
-    var x: 0
-    while x < 10
-      @out x
-      x: x + 1
+    // `<change>` expression is optional
+    var i: 0
+    while i < 10 {i: i + 1}
+      @out i
     end
     ```
 

--- a/README.md
+++ b/README.md
@@ -226,9 +226,9 @@ By inputting code from either a file or via the REPL, the VM will interpret it a
 | `var x: 1`<br>`var y: 2`<br>`var z: x: y`<br>`@out x`<br>`@out z` | 2<br>2         |
 | `var x: "global"`<br>`@out x`<br><br>`block`<br>`  x: "changed global"`<br>`  var x: "local"`<br>`  @out x`<br>`end`<br><br>`@out x` | global<br>local<br>changed global         |
 | `var x: 0`<br>`if x < 5`<br>`  @out "in if"`<br>`else`<br>`  @out "in else"`<br>`end` | in if   |
-| `var x: 0`<br>`while x < 5`<br>`  @out x`<br>`  x: x + 1`<br>`end` | 0<br>1<br>2<br>3<br>4   |
 | `foreach value in 0..2`<br>`  @out value`<br>`end` | 0<br>1<br>2   |
 | `var a: 0`<br>`var b: 2`<br>`var c: 0.5`<br>`foreach value in a..b step c`<br>`  @out value`<br>`end` | 0<br>0.5<br>1<br>1.5<br>2   |
+| `var x: 0`<br>`while x < 4 {x: x + 1}`<br>`  @out x`<br>`end` | 0<br>1<br>2<br>3   |
 
 **Table 3: Invalid user input**
 

--- a/design/grammar.txt
+++ b/design/grammar.txt
@@ -71,7 +71,7 @@ varStatement:
 	| "var" IDENTIFIER ":" expression NEWLINE
 
 whileStatement:
-	| "while" expression standardBlock
+	| "while" expression ( "{" expression "}" )? standardBlock
 
 ------------------------------------------------------------------
 HELPER RULES

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -306,7 +306,12 @@ Token tokenize(Tokenizer* tokenizer) {
         return make_token(tokenizer, TOKEN_DOT_DOT);
       return make_error_token(tokenizer, "You have included an illegal character: . (This character is only allowed as `..`.)");
     }
+    case '{':
+      return make_token(tokenizer, TOKEN_OPEN_BRACE);
+    case '}':
+      return make_token(tokenizer, TOKEN_CLOSE_BRACE);
     default:
+      // TODO: Consider putting these first (before the switch).
       if (is_alpha(character))
         return consume_keyword_or_identifier(tokenizer);
       if (is_digit(character))

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -7,6 +7,7 @@
 
 typedef enum {
   // Punctuation and non-keyword operators
+  TOKEN_CLOSE_BRACE,
   TOKEN_CLOSE_PAREN,
   TOKEN_COLON,
   // TOKEN_COMMA,
@@ -19,6 +20,7 @@ typedef enum {
   TOKEN_LESS_THAN,
   TOKEN_LESS_THAN_EQUALS,
   TOKEN_MINUS,
+  TOKEN_OPEN_BRACE,
   TOKEN_OPEN_PAREN,
   TOKEN_PLUS,
   TOKEN_SLASH,


### PR DESCRIPTION
## Additions / Changes

### Description

Extends the `while` statement with support for providing an expression after the condition. This allows modifications to a variable to be executed after the body is executed without the need to add it in the body itself. (See example further below.)

```
while <condition> { <change> }
  <statements>
end
```

**Notes:**
* `{ <change> }` is optional.

### Semantics

**Flow:**
1. Evaluate the `<condition>`
2. If `true`
    1. Execute `<statements>`
    2. Execute `<change>`
    3. Go to step 1.
3. If `false`
    1. Exit the loop

### Examples of Expected Behavior

| Example valid input     | Expected output   |
|-------------------------|-------------------|
| `var x: 0`<br>`while x < 4 {x: x + 1}`<br>`  @out x`<br>`end` | 0<br>1<br>2<br>3   |

## Checklist

| Item                                                | Done | Not Applicable |
|-----------------------------------------------------|------|----------------|
| Updated the README                                  | x    |                |
| Added the new statement as a synchronization point  |      | x              |
