### PR TITLE
Implement augmented assignment (`*:`, multiply-assign)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The development of both the language and the surrounding documentation is curren
 - [ ] Augmented assignment expressions can be evaluated.
   - [x] Addition and assignment (`+:`)
   - [x] Subtraction and assignment (`-:`)
-  - [ ] Multiplication and assignment (`*:`)
+  - [x] Multiplication and assignment (`*:`)
   - [ ] Division and assignment (`/:`)
   - [ ] Modulo and assignment (`mod:`)
 - [ ] Range comparison expression can be evaluated (`<value> in <min>..<max>`)

--- a/design/grammar.txt
+++ b/design/grammar.txt
@@ -93,7 +93,7 @@ expression:
 
 # TODO: Prefix with `( call "." )?` when adding calls
 assignment:
-	| IDENTIFIER ( ":" | "+:" | "-:" ) expression
+	| IDENTIFIER ( ":" | "+:" | "-:" | "*:" ) expression
 
 disjunction:
 	| conjunction ( "or" conjunction )*

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -122,6 +122,7 @@ static ParseRule rules[] = {
   [TOKEN_PLUS_COLON]            = { NULL, NULL, PRECEDENCE_IGNORE },
   [TOKEN_SLASH]                 = { NULL, parse_binary, PRECEDENCE_FACTOR },
   [TOKEN_STAR]                  = { NULL, parse_binary, PRECEDENCE_FACTOR },
+  [TOKEN_STAR_COLON]            = { NULL, NULL, PRECEDENCE_IGNORE },
 
   // Reserved keywords
   [TOKEN_AND]                   = { NULL, parse_and, PRECEDENCE_CONJUNCTION },
@@ -497,8 +498,9 @@ static int resolve(Parser* parser, Token* name) {
 static bool is_assignment_operator(Token* token) {
   switch (token->type) {
     case TOKEN_COLON:
-    case TOKEN_MINUS_COLON:
     case TOKEN_PLUS_COLON:
+    case TOKEN_MINUS_COLON:
+    case TOKEN_STAR_COLON:
       return true;
     default:
       return false;
@@ -524,6 +526,8 @@ static void assign_variable(Parser* parser, byte stack_slot) {
       write_instruction(parser, OP_ADD);
     else if (type == TOKEN_MINUS_COLON)
       write_instruction(parser, OP_SUBTRACT);
+    else if (type == TOKEN_STAR_COLON)
+      write_instruction(parser, OP_MULTIPLY);
     else
       error_at(parser, &operator, "Internal error. Expected an assignment operator.");
   }

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -278,7 +278,9 @@ Token tokenize(Tokenizer* tokenizer) {
         ? make_token(tokenizer, TOKEN_MINUS_COLON)
         : make_token(tokenizer, TOKEN_MINUS);
     case '*':
-      return make_token(tokenizer, TOKEN_STAR);
+      return match(tokenizer, ':')
+        ? make_token(tokenizer, TOKEN_STAR_COLON)
+        : make_token(tokenizer, TOKEN_STAR);
     case '/':
       return make_token(tokenizer, TOKEN_SLASH);
     case '=':

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -27,6 +27,7 @@ typedef enum {
   TOKEN_PLUS_COLON,
   TOKEN_SLASH,
   TOKEN_STAR,
+  TOKEN_STAR_COLON,
 
   // Reserved keywords
   TOKEN_AND,


### PR DESCRIPTION
## 🛠 Additions / Changes

### Description

Adds support for the following augmented assignment operator:
* Multiply-assign (`*:`)

### Semantics

* The operator is a shorthand for multiplying and assigning.
  * E.g. `x *: 2` is executed as `x: x * 2`. 
* The precedence is equal to that of a regular assignment (`:`).
* The expression evaluates to the assigned value.

### Examples of Expected Behavior

| Example valid input     | Expected output   |
|-------------------------|-------------------|
| `var x: 5`<br>`x *: 2`<br>`@out x` | 10  |
| `var x: 1`<br>`while x < 5 {x *: 2}`<br>`  @out x`<br>`end` | 1<br>2<br>4   |

## 🗒️ Checklist

| Item                                                | Done | Not Applicable |
|:----------------------------------------------------|:----:|:--------------:|
| Updated the README                                  | x    |                |
| Added the new statement as a synchronization point  |      | x              |
