### PR TITLE
Support accepting debug flags from user

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,17 +262,24 @@ Run the below command to make Thusly come to life. It will create a top-level `b
 
 Once you have [built](#building-the-project) the project you can go ahead and feed it some code to interpret thusly (..get it?):
 
-**Usage example** (use the flag `-h` or `--help`):
+**Usage example:**
 
 ```
 $ ./bin/cthusly --help
 
 Usage: ./bin/cthusly [options] [path]
 
-    REPL (interactive prompt) starts if no [path] is provided
+    The REPL (interactive prompt) starts if no path is provided
 
-    -h, --help                Show usage
+    -h,     --help           Show usage
+    -d,     --debug          Enable all debug flags below
+    -dcomp, --debug-comp     Show compiler output (bytecode)
+    -dexec, --debug-exec     Show VM execution trace
 ```
+
+> **Flags:**
+>
+> Currently, only 1 flag may be provided.
 
 **Interpret code from a file:**
 
@@ -286,6 +293,10 @@ Usage: ./bin/cthusly [options] [path]
 ./bin/cthusly
 ```
 
+> **Exit REPL:**
+>
+> Press `Cmd + D` (Mac) or `Ctrl + D` (Windows).
+
 Example:
 
 ```
@@ -297,16 +308,6 @@ true
 2.25
 > 
 ```
-
-> **Enable/disable debug output:**
->
-> Comment or uncomment the following macros in [src/common.h](src/common.h) to disable or enable printouts (then [rebuild](#building-the-project) the project):
->
-> **DEBUG_COMPILATION**
->   - Prints the entire bytecode produced by the compiler.
->
-> **DEBUG_EXECUTION**
->   - Prints the VM execution steps including its stack state.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ $ ./bin/cthusly --help
 
 Usage: ./bin/cthusly [options] [path]
 
-    The REPL (interactive prompt) starts if no path is provided
+    The REPL (interactive prompt) starts if no [path] is provided
 
     -h,     --help           Show usage
     -d,     --debug          Enable all debug flags below

--- a/README.md
+++ b/README.md
@@ -309,6 +309,14 @@ true
 > 
 ```
 
+> **Enable/disable debug:**
+>
+> For the [debug flags](#running-code) to have an effect, the following macro in [src/common.h](src/common.h) need to be defined.
+>
+> * **DEBUG_MODE**
+>
+> You may comment or uncomment it to disable or enable support for the flags (then [rebuild](#building-the-project) the project).
+
 ## License
 
 This software is licensed under the terms of the [MIT license](LICENSE).

--- a/src/common.h
+++ b/src/common.h
@@ -5,18 +5,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// Comment/uncomment to disable/enable debug output
-// #define DEBUG_COMPILATION
-// #define DEBUG_EXECUTION
-
-// Comment/uncomment to disable/enable debug mode.
+// Comment/uncomment to disable/enable support for debug flags.
 // (Whether to print output is still controlled via the flags.)
 #define DEBUG_MODE
 
-#ifdef DEBUG_MODE
 extern bool flag_debug_compilation;
 extern bool flag_debug_execution;
-#endif
 
 typedef uint8_t byte;
 

--- a/src/common.h
+++ b/src/common.h
@@ -6,8 +6,17 @@
 #include <stdint.h>
 
 // Comment/uncomment to disable/enable debug output
-#define DEBUG_COMPILATION
-#define DEBUG_EXECUTION
+// #define DEBUG_COMPILATION
+// #define DEBUG_EXECUTION
+
+// Comment/uncomment to disable/enable debug mode.
+// (Whether to print output is still controlled via the flags.)
+#define DEBUG_MODE
+
+#ifdef DEBUG_MODE
+extern bool flag_debug_compilation;
+extern bool flag_debug_execution;
+#endif
 
 typedef uint8_t byte;
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -9,7 +9,7 @@
 #include "thusly_value.h"
 #include "tokenizer.h"
 
-#ifdef DEBUG_COMPILATION
+#ifdef DEBUG_MODE
 #include "debug.h"
 #endif
 
@@ -932,8 +932,8 @@ static void parse_variable(Parser* parser, bool is_assignable) {
 static void end_compilation(Parser* parser) {
   write_return_instruction(parser);
 
-  #ifdef DEBUG_COMPILATION
-    if (!parser->saw_error)
+  #ifdef DEBUG_MODE
+    if (flag_debug_compilation && !parser->saw_error)
       disassemble_program(get_writable_program(parser), "Program");
   #endif
 }

--- a/src/main.c
+++ b/src/main.c
@@ -8,15 +8,22 @@
 #include "program.h"
 #include "vm.h"
 
+#ifdef DEBUG_MODE
+bool flag_debug_compilation = false;
+bool flag_debug_execution = false;
+#endif
+
 static void print_help(FILE* fout) {
   fprintf(fout,
     "\n"
     "Usage: ./bin/cthusly [options] [path]\n"
     "\n"
-    "    The REPL (interactive prompt) starts if no [path] is provided\n"
+    "    The REPL (interactive prompt) starts if no arguments are provided\n"
     "\n"
-    "    -h, --help                Show usage\n"
-    "\n"
+    "    -h,     --help           Show usage\n"
+    "    -d,     --debug          Show compiler output (bytecode) and VM execution trace\n"
+    "    -dcomp, --debug-comp     Show compiler output (bytecode)\n"
+    "    -dexec, --debug-exec     Show VM execution trace\n"
   );
 }
 
@@ -91,8 +98,10 @@ static void run_file(const char* path) {
 }
 
 int main(int argc, const char* argv[]) {
+  // Example input: ./cthusly
   if (argc == 1)
     run_repl();
+  // Example input: ./cthusly path/to/file
   else if (argc == 2) {
     const char* argv1 = argv[1];
     if (strcmp(argv1, "-h") == 0 || strcmp(argv1, "--help") == 0)
@@ -100,12 +109,27 @@ int main(int argc, const char* argv[]) {
     else
       run_file(argv1);
   }
-  /*else if (argc == 3) {
-    // TODO:
-    // Currently only allowing '-h' or '--help' without providing the [path] as
-    // the next arg. Other flags, e.g. debug flags, will be allowed as the arg
-    // preceding the [path]. Add to this block when 3 args are supported.
-  }*/
+  // Example input: ./cthusly --debug path/to/file
+  else if (argc == 3) {
+    #ifdef DEBUG_MODE
+      const char* flag = argv[1];
+      if (strcmp(flag, "-d") == 0 || strcmp(flag, "--debug") == 0) {
+        flag_debug_compilation = true;
+        flag_debug_execution = true;
+      }
+      else if (strcmp(flag, "-dcomp") == 0 || strcmp(flag, "--debug-comp") == 0)
+        flag_debug_compilation = true;
+      else if (strcmp(flag, "-dexec") == 0 || strcmp(flag, "--debug-exec") == 0)
+        flag_debug_execution = true;
+      else {
+        print_help(stderr);
+        return EXIT_CODE_USAGE_ERROR;
+      }
+    #endif
+
+    const char* path = argv[2];
+    run_file(path);
+  }
   else {
     print_help(stderr);
     return EXIT_CODE_USAGE_ERROR;

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,7 @@ static void print_help(FILE* fout) {
     "\n"
     "Usage: ./bin/cthusly [options] [path]\n"
     "\n"
-    "    The REPL (interactive prompt) starts if no arguments are provided\n"
+    "    The REPL (interactive prompt) starts if no [path] is provided\n"
     "\n"
     "    -h,     --help           Show usage\n"
     "    -d,     --debug          Show compiler output (bytecode) and VM execution trace\n"

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "common.h"
 #include "gc_object.h"
 #include "memory.h"
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "common.h"
 #include "gc_object.h"
 #include "memory.h"
 
@@ -35,8 +36,9 @@ static void free_object(GCObject* object) {
 
 void free_objects(Environment* environment) {
   // -- TEMPORARY --
-  #ifdef DEBUG_EXECUTION
-    printf("FREEING GC OBJECTS..\n");
+  #ifdef DEBUG_MODE
+    if (flag_debug_execution)
+      printf("FREEING GC OBJECTS..\n");
   #endif
   // ---------------
 

--- a/src/program.c
+++ b/src/program.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include "common.h"
 #include "memory.h"
 #include "program.h"
 
@@ -12,8 +13,9 @@ static void constant_pool_init(ConstantPool* pool) {
 
 static void constant_pool_free(ConstantPool* pool) {
   // -- TEMPORARY --
-  #ifdef DEBUG_EXECUTION
-    printf("FREEING CONSTANT POOL..\n");
+  #ifdef DEBUG_MODE
+    if (flag_debug_execution)
+      printf("FREEING CONSTANT POOL..\n");
   #endif
   // ---------------
 
@@ -43,8 +45,9 @@ void program_init(Program* program) {
 
 void program_free(Program* program) {
   // -- TEMPORARY --
-  #ifdef DEBUG_EXECUTION
-    printf("FREEING PROGRAM..\n");
+  #ifdef DEBUG_MODE
+    if (flag_debug_execution)
+      printf("FREEING PROGRAM..\n");
   #endif
   // ---------------
 

--- a/src/program.c
+++ b/src/program.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include "common.h"
 #include "memory.h"
 #include "program.h"
 

--- a/src/table.c
+++ b/src/table.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "common.h"
 #include "gc_object.h"
 #include "memory.h"
 #include "table.h"

--- a/src/table.c
+++ b/src/table.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "common.h"
 #include "gc_object.h"
 #include "memory.h"
 #include "table.h"
@@ -17,8 +18,9 @@ void table_init(Table* table) {
 
 void table_free(Table* table) {
   // -- TEMPORARY --
-  #ifdef DEBUG_EXECUTION
-    printf("FREEING TABLE..\n");
+  #ifdef DEBUG_MODE
+    if (flag_debug_execution)
+      printf("FREEING TABLE..\n");
   #endif
   // ---------------
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -24,8 +24,9 @@ void vm_init(VM* vm) {
 
 void vm_free(VM* vm) {
   // -- TEMPORARY --
-  #ifdef DEBUG_EXECUTION
-    printf("FREEING VM..\n");
+  #ifdef DEBUG_MODE
+    if (flag_debug_execution)
+      printf("FREEING VM..\n");
   #endif
   // ---------------
 
@@ -117,17 +118,18 @@ static ErrorReport decode_and_execute(VM* vm) {
       push(vm, from_c_value(a operator b));                                                 \
     } while (false)
 
-  #ifdef DEBUG_EXECUTION
-  printf("========== Execution ==========\n");
+  #ifdef DEBUG_MODE
+    if (flag_debug_execution)
+      printf("========== Execution ==========\n");
   #endif
 
   while (true) {
-    #ifdef DEBUG_EXECUTION
-    {
-      disassemble_stack(vm);
-      int offset = (int)(vm->next_instruction - vm->program->instructions);
-      disassemble_instruction(vm->program, offset);
-    }
+    #ifdef DEBUG_MODE
+      if (flag_debug_execution) {
+        disassemble_stack(vm);
+        int offset = (int)(vm->next_instruction - vm->program->instructions);
+        disassemble_instruction(vm->program, offset);
+      }
     #endif
 
     byte instruction = READ_BYTE();


### PR DESCRIPTION
## 🛠 Additions / Changes

### Description

Adds support for accepting debug flags from the user when starting the program.

In addition to the existing `-h` or `--help` flag, three new flags have been introduced as shown in this usage example:

```
$ ./bin/cthusly --help

Usage: ./bin/cthusly [options] [path]

    The REPL (interactive prompt) starts if no [path] is provided

    -h,     --help           Show usage
    -d,     --debug          Enable all debug flags below
    -dcomp, --debug-comp     Show compiler output (bytecode)
    -dexec, --debug-exec     Show VM execution trace
```

#### Enable/disable debug

For the debug flags to have an effect, the following macro in `src/common.h` need to be defined.
* **DEBUG_MODE**

(It can be commented out or uncommented in order to disable or enable support for the flags.)

> Only 1 flag can currently be provided.

## 🗒️ Checklist

| Item                                                | Done | Not Applicable |
|:----------------------------------------------------|:----:|:--------------:|
| Updated the README                                  | x    |                |
| Added the new statement as a synchronization point  |      | x              |
