### PR TITLE
[playground] Support interpreting Thusly code in the browser

### DIFF
--- a/build_playground.sh
+++ b/build_playground.sh
@@ -15,7 +15,18 @@ mkdir dist
 echo "Done!"
 
 echo -e "\nCompiling to Wasm and generating distribution files..."
-emcc -o dist/index.html src/main_wasm.c -O3 --shell-file src/playground.html
+# Flags:
+# -o:
+#   To where the compiler should output the JavaScript glue code and HTML.
+# -03:
+#   Enables the highest optimization.
+#   (Levels: -O0 (no optimization), -O1, -O2, -Os, -Oz, -Og, and -O3)
+# --shell-file:
+#   The path to the HTML template to use to create the distributed HTML.
+# -s NO_EXIT_RUNTIME=1:
+#   Prevents the runtime from shutting down when `main()` exits,
+#   which would invalidate calls to compiled code.
+emcc src/main_wasm.c -o dist/index.html -O3 --shell-file src/playground.html -s NO_EXIT_RUNTIME=1 -s "EXPORTED_RUNTIME_METHODS=['ccall']"
 cp src/*.js dist
 echo "Done!"
 

--- a/build_playground.sh
+++ b/build_playground.sh
@@ -37,6 +37,7 @@ files_to_compile="$source_dir/main_wasm.c $interpreter_dir/*.c"
 #   (Adding this option until `$interpreter_dir/main.c` can be removed from `$files_to_compile`.)
 emcc $files_to_compile -o $output_dir/index.html -O3 --shell-file $source_dir/playground.html -s NO_EXIT_RUNTIME=1 -s "EXPORTED_RUNTIME_METHODS=['ccall']" --no-entry
 cp $source_dir/*.js $output_dir
+cp $source_dir/*.css $output_dir
 echo "Done!"
 
 echo -e "\nCongratulations! You can start the playground by opening \`$output_dir/index.html\` in the browser via an \`http://\` server (not \`file://\`)."

--- a/build_playground.sh
+++ b/build_playground.sh
@@ -4,18 +4,24 @@
 if ! which emcc;
 then
   echo -e "\nConfiguration error: Emscripten was not found. Please install the recommended emsdk and rerun the script."
-  echo "If Emscripten is installed, make sure to enable its command by running 'source path/to/emsdk_env.sh' in your terminal."
+  echo "If Emscripten is installed, make sure to enable its command by running \`source path/to/emsdk_env.sh\` in your terminal."
   exit 1
 fi
 
-echo -e "\nCreating directory 'playground/dist' for the distribution files..."
-cd playground
-rm -rf dist
-mkdir dist
+output_dir="playground/dist"
+source_dir="playground/src"
+interpreter_dir=src
+
+echo -e "\nCreating directory \`$output_dir\` for the distribution files..."
+rm -rf $output_dir
+mkdir $output_dir
 echo "Done!"
 
 echo -e "\nCompiling to Wasm and generating distribution files..."
-# Flags:
+# TODO: Don't import `$interpreter_dir/main.c`
+# files_to_compile="$source_dir/main_wasm.c $interpreter_dir/compiler.c $interpreter_dir/debug.c $interpreter_dir/gc_object.c $interpreter_dir/memory.c $interpreter_dir/program.c $interpreter_dir/table.c $interpreter_dir/thusly_value.c $interpreter_dir/tokenizer.c $interpreter_dir/vm.c"
+files_to_compile="$source_dir/main_wasm.c $interpreter_dir/*.c"
+# Flags: (see https://emscripten.org/docs/tools_reference/emcc.html)
 # -o:
 #   To where the compiler should output the JavaScript glue code and HTML.
 # -03:
@@ -26,11 +32,11 @@ echo -e "\nCompiling to Wasm and generating distribution files..."
 # -s NO_EXIT_RUNTIME=1:
 #   Prevents the runtime from shutting down when `main()` exits,
 #   which would invalidate calls to compiled code.
-emcc src/main_wasm.c -o dist/index.html -O3 --shell-file src/playground.html -s NO_EXIT_RUNTIME=1 -s "EXPORTED_RUNTIME_METHODS=['ccall']"
-cp src/*.js dist
+# --no-entry:
+#   Will not enter `main()` function.
+#   (Adding this option until `$interpreter_dir/main.c` can be removed from `$files_to_compile`.)
+emcc $files_to_compile -o $output_dir/index.html -O3 --shell-file $source_dir/playground.html -s NO_EXIT_RUNTIME=1 -s "EXPORTED_RUNTIME_METHODS=['ccall']" --no-entry
+cp $source_dir/*.js $output_dir
 echo "Done!"
 
-echo -e "\nCongratulations! You can start the playground by opening 'playground/dist/index.html' in the browser via an 'http://' server (not 'file://')."
-
-# Navigate back to the root.
-cd ..
+echo -e "\nCongratulations! You can start the playground by opening \`$output_dir/index.html\` in the browser via an \`http://\` server (not \`file://\`)."

--- a/playground/README.md
+++ b/playground/README.md
@@ -17,7 +17,7 @@ An interactive playground in the browser for the Thusly programming language.
 
 ### Building the Project
 
-Run the below command to compile the C source code to Wasm and generate browser distribution files to `playground/dist`.
+Run the below command to compile the C source code to WebAssembly and generate browser distribution files to `playground/dist`.
 
 ```sh
 ./build_playground.sh

--- a/playground/src/main_wasm.c
+++ b/playground/src/main_wasm.c
@@ -1,6 +1,27 @@
 #include <stdio.h>
+#include <stdlib.h>
+
+#include <emscripten/emscripten.h>
+
+// If this was to be ported to C++, this macro is needed so that it treats it as an external C function.
+#ifdef __cplusplus
+#define EXTERN extern "C"
+#else
+#define EXTERN
+#endif
+
+// Using `EMSCRIPTEN_KEEPALIVE` before the function name prevents Emscripten-generated code
+// from eliminating it as dead code. (It always just calls the `main()` function by default.)
+EMSCRIPTEN_KEEPALIVE
+int run_source(char* code) {
+  // Must always end with newline!
+  printf("'run_source()' called with:\n%s\n", code);
+  free(code);
+
+  return 0;
+}
 
 int main() {
-  printf("Hello Thusly Programmer!\n");
+  printf("Hey, welcome to the Thusly playground!\n");
   return 0;
 }

--- a/playground/src/main_wasm.c
+++ b/playground/src/main_wasm.c
@@ -3,25 +3,42 @@
 
 #include <emscripten/emscripten.h>
 
+#include "../../src/exit_code.h"
+#include "../../src/vm.h"
+
 // If this was to be ported to C++, this macro is needed so that it treats it as an external C function.
-#ifdef __cplusplus
-#define EXTERN extern "C"
-#else
-#define EXTERN
-#endif
+// #ifdef __cplusplus
+// #define EXTERN extern "C"
+// #else
+// #define EXTERN
+// #endif
 
 // Using `EMSCRIPTEN_KEEPALIVE` before the function name prevents Emscripten-generated code
 // from eliminating it as dead code. (It always just calls the `main()` function by default.)
-EMSCRIPTEN_KEEPALIVE
+/*EXTERN*/ EMSCRIPTEN_KEEPALIVE
 int run_source(char* code) {
-  // Must always end with newline!
-  printf("'run_source()' called with:\n%s\n", code);
+  VM vm;
+  vm_init(&vm);
+
+  ErrorReport report = interpret(&vm, code);
+
   free(code);
+  vm_free(&vm);
+
+  // Must always end with newline!
+  printf("\n");
+
+  if (report == REPORT_COMPILE_ERROR)
+    return EXIT_CODE_INPUT_DATA_ERROR;
+  if (report == REPORT_RUNTIME_ERROR)
+    return EXIT_CODE_INTERNAL_SOFTWARE_ERROR;
 
   return 0;
 }
 
-int main() {
-  printf("Hey, welcome to the Thusly playground!\n");
-  return 0;
-}
+// Uncomment if not using `--no-entry` on Emscripten compilation and removing
+// `$interpreter_dir/main.c` from the `$files_to_compile`.
+// int main() {
+//   printf("Hey, welcome to the Thusly playground!\n");
+//   return EXIT_SUCCESS;
+// }

--- a/playground/src/playground.html
+++ b/playground/src/playground.html
@@ -74,9 +74,22 @@
     </div>
     <hr/>
     <textarea class="emscripten" id="output" rows="8"></textarea>
+    <button id="run">Run</button>
     <hr>
 
-    <script src="wasm_setup.js" type='text/javascript'></script>
+    <script src="wasm_setup.js" type="text/javascript"></script>
+
+    <script>
+      const code = "var x: 1";
+      document.getElementById("run").addEventListener("click", () => {
+        const result = Module.ccall(
+          "run_source",   // C function name
+          "int",          // Return type
+          ["string"],     // Argument types
+          [code],         // Arguments
+        );
+    });
+    </script>
 
     {{{ SCRIPT }}}
 

--- a/playground/src/playground.html
+++ b/playground/src/playground.html
@@ -4,60 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Thusly - Interactive Playground</title>
-    <style>
-      .emscripten {
-        padding-right: 0;
-        margin-left: auto;
-        margin-right: auto;
-        display: block;
-      }
-      textarea.emscripten {
-        font-family: monospace;
-        width: 80%;
-      }
-      div.emscripten {
-        text-align: center;
-      }
-      div.emscripten_border {
-        border: 1px solid black;
-      }
-      /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten {
-        border: 0px none;
-        background-color: black;
-      }
-      .spinner {
-        height: 50px;
-        width: 50px;
-        margin: 0px auto;
-        -webkit-animation: rotation .8s linear infinite;
-        -moz-animation: rotation .8s linear infinite;
-        -o-animation: rotation .8s linear infinite;
-        animation: rotation 0.8s linear infinite;
-        border-left: 10px solid rgb(0,150,240);
-        border-right: 10px solid rgb(0,150,240);
-        border-bottom: 10px solid rgb(0,150,240);
-        border-top: 10px solid rgb(100,0,200);
-        border-radius: 100%;
-        background-color: rgb(200,100,250);
-      }
-      @-webkit-keyframes rotation {
-        from {-webkit-transform: rotate(0deg);}
-        to {-webkit-transform: rotate(360deg);}
-      }
-      @-moz-keyframes rotation {
-        from {-moz-transform: rotate(0deg);}
-        to {-moz-transform: rotate(360deg);}
-      }
-      @-o-keyframes rotation {
-        from {-o-transform: rotate(0deg);}
-        to {-o-transform: rotate(360deg);}
-      }
-      @keyframes rotation {
-        from {transform: rotate(0deg);}
-        to {transform: rotate(360deg);}
-      }
-    </style>
+    <link rel="stylesheet" href="styles.css">
   </head>
 
   <body>

--- a/playground/src/playground.html
+++ b/playground/src/playground.html
@@ -73,24 +73,26 @@
       <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
     </div>
     <hr/>
-    <textarea class="emscripten" id="output" rows="8"></textarea>
+    <textarea class="emscripten" id="input" rows="20"></textarea>
+    <textarea class="emscripten" id="output" rows="10"></textarea>
     <button id="run">Run</button>
     <hr>
 
     <script src="wasm_setup.js" type="text/javascript"></script>
 
-    <script>
-      const code = "var x: 1";
+    <script type="text/javascript">
       document.getElementById("run").addEventListener("click", () => {
-        const result = Module.ccall(
-          "run_source",   // C function name
-          "int",          // Return type
-          ["string"],     // Argument types
-          [code],         // Arguments
-        );
-    });
+        const code = document.getElementById("input").value;
+        clearOutput();
+        run(code);
+      });
+
+      function clearOutput() {
+        document.getElementById("output").value = "";
+      }
     </script>
 
+    <!-- Emscripten -->
     {{{ SCRIPT }}}
 
   </body>

--- a/playground/src/styles.css
+++ b/playground/src/styles.css
@@ -1,0 +1,52 @@
+.emscripten {
+  padding-right: 0;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+textarea.emscripten {
+  font-family: monospace;
+  width: 80%;
+}
+div.emscripten {
+  text-align: center;
+}
+div.emscripten_border {
+  border: 1px solid black;
+}
+/* the canvas *must not* have any border or padding, or mouse coords will be wrong */
+canvas.emscripten {
+  border: 0px none;
+  background-color: black;
+}
+.spinner {
+  height: 50px;
+  width: 50px;
+  margin: 0px auto;
+  -webkit-animation: rotation .8s linear infinite;
+  -moz-animation: rotation .8s linear infinite;
+  -o-animation: rotation .8s linear infinite;
+  animation: rotation 0.8s linear infinite;
+  border-left: 10px solid rgb(0,150,240);
+  border-right: 10px solid rgb(0,150,240);
+  border-bottom: 10px solid rgb(0,150,240);
+  border-top: 10px solid rgb(100,0,200);
+  border-radius: 100%;
+  background-color: rgb(200,100,250);
+}
+@-webkit-keyframes rotation {
+  from {-webkit-transform: rotate(0deg);}
+  to {-webkit-transform: rotate(360deg);}
+}
+@-moz-keyframes rotation {
+  from {-moz-transform: rotate(0deg);}
+  to {-moz-transform: rotate(360deg);}
+}
+@-o-keyframes rotation {
+  from {-o-transform: rotate(0deg);}
+  to {-o-transform: rotate(360deg);}
+}
+@keyframes rotation {
+  from {transform: rotate(0deg);}
+  to {transform: rotate(360deg);}
+}

--- a/src/main.c
+++ b/src/main.c
@@ -3,9 +3,7 @@
 #include <string.h>
 
 #include "common.h"
-#include "debug.h"
 #include "exit_code.h"
-#include "program.h"
 #include "vm.h"
 
 bool flag_debug_compilation = false;


### PR DESCRIPTION
## 🛠 Additions / Changes

### Description

Users can input Thusly code to an HTML DOM element value and click `Run` whereby:
1. A C function will be called via Wasm.
2. The function initializes a VM that interprets the given input.
3. The output is added to an HTML DOM element.

## 🗒️ Checklist

| Item                                                | Done | Not Applicable |
|:----------------------------------------------------|:----:|:--------------:|
| Updated the README                                  |      |  x             |
| Added the new statement as a synchronization point  |      |  x             |
