### PR TITLE
[playground] Support accepting debug flags in the browser

### DIFF
--- a/playground/src/main_wasm.c
+++ b/playground/src/main_wasm.c
@@ -3,6 +3,7 @@
 
 #include <emscripten/emscripten.h>
 
+#include "../../src/common.h"
 #include "../../src/exit_code.h"
 #include "../../src/vm.h"
 
@@ -13,10 +14,17 @@
 // #define EXTERN
 // #endif
 
+// Uncomment when removing `$interpreter_dir/main.c` from the `$files_to_compile`.
+// bool flag_debug_compilation = false;
+// bool flag_debug_execution = false;
+
 // Using `EMSCRIPTEN_KEEPALIVE` before the function name prevents Emscripten-generated code
 // from eliminating it as dead code. (It always just calls the `main()` function by default.)
 /*EXTERN*/ EMSCRIPTEN_KEEPALIVE
-int run_source(char* code) {
+int run_source(char* code, bool debug_compilation, bool debug_execution) {
+  flag_debug_compilation = debug_compilation;
+  flag_debug_execution = debug_execution;
+
   VM vm;
   vm_init(&vm);
 

--- a/playground/src/playground.html
+++ b/playground/src/playground.html
@@ -13,6 +13,7 @@
   </head>
 
   <body>
+    <!-- Temporary -->
     <figure style="overflow:visible;" id="spinner">
       <div class="spinner"></div><center style="margin-top:0.5em"><strong>emscripten</strong></center>
     </figure>
@@ -23,11 +24,32 @@
       <progress value="0" max="100" id="progress" hidden=1></progress>
     </div>
     <hr/>
+    <!---->
+
+
+    <div>
+      <div>
+        <div>
+          <label for="debug-compilation">Bytecode</label>
+          <input
+            type="checkbox"
+            id="debug-compilation"
+            name="debug-compilation"
+          />
+        </div>
+        <label for="debug-execution">Execution</label>
+        <input
+          type="checkbox"
+          id="debug-execution"
+          name="debug-execution"
+        />
+      </div>
+      <button id="run">
+        Run
+      </button>
+    </div>
     <div id="editor"></div>
     <textarea readonly class="emscripten" id="output" rows="10"></textarea>
-    <button id="run">
-      Run
-    </button>
 
     <!-- Load the Wasm setup first. -->
     <script src="wasm_setup.js" type="text/javascript"></script>

--- a/playground/src/playground.html
+++ b/playground/src/playground.html
@@ -44,7 +44,8 @@
           name="debug-execution"
         />
       </div>
-      <button id="run">
+      <!-- The button will become enabled when `Module.onRuntimeInitialized`. -->
+      <button id="run" disabled>
         Run
       </button>
     </div>

--- a/playground/src/playground.js
+++ b/playground/src/playground.js
@@ -1,9 +1,12 @@
 import { editor } from "./editor_setup.js";
 
+const debugCompilationElement = document.getElementById("debug-compilation");
+const debugExecutionElement = document.getElementById("debug-execution");
+
 document.getElementById("run").addEventListener("click", () => {
   clearOutput();
   const code = editor.getValue();
-  run(code);
+  run(code, debugCompilationElement.checked, debugExecutionElement.checked);
 });
 
 function clearOutput() {

--- a/playground/src/wasm_setup.js
+++ b/playground/src/wasm_setup.js
@@ -1,4 +1,6 @@
 const outputElement = document.getElementById("output");
+const runElement = document.getElementById("run");
+
 const statusElement = document.getElementById("status");
 const progressElement = document.getElementById("progress");
 const spinnerElement = document.getElementById("spinner");
@@ -54,7 +56,8 @@ var Module = {
         ["string", "boolean", "boolean"],         // Argument types
         [code, debugCompilation, debugExecution], // Arguments
       );
-    }
+    };
+    runElement.removeAttribute("disabled");
   },
 
   setStatus: (text) => {

--- a/playground/src/wasm_setup.js
+++ b/playground/src/wasm_setup.js
@@ -44,15 +44,15 @@ var Module = {
 
   // Invoked when the runtime is fully initialized; i.e., when compiled code is safe to run.
   onRuntimeInitialized: () => {
-    run = function(code) {
+    run = function(code, debugCompilation, debugExecution) {
       if (!code)
         return;
 
       Module.ccall(
-        "run_source",   // C function name
-        "int",          // Return type
-        ["string"],     // Argument types
-        [code],         // Arguments
+        "run_source",                             // C function name
+        "int",                                    // Return type
+        ["string", "boolean", "boolean"],         // Argument types
+        [code, debugCompilation, debugExecution], // Arguments
       );
     }
   },


### PR DESCRIPTION
## 🛠 Additions / Changes

### Description

Adds support for accepting debug flags in the browser playground.

The user can check either or both of the following check marks:
* `Bytecode`
  * Show the compilation bytecode output.
* `Execution`
  * Show the VM execution trace. 

## 🗒️ Checklist

| Item                                                | Done | Not Applicable |
|:----------------------------------------------------|:----:|:--------------:|
| Updated the README                                  |      |   x            |
| Added the new statement as a synchronization point  |      |  x             |
