### PR TITLE
[playground] Support choosing a code snippet to start with

### DIFF
--- a/playground/src/editor_setup.js
+++ b/playground/src/editor_setup.js
@@ -3,12 +3,15 @@ import { snippets } from "./snippets.js";
 const languageId = "thusly";
 
 const editorConfiguration = {
-  name: "overview.thusly",
+  // name: "overview.thusly",
   language: languageId,
+  // extraEditorClassName: "thusly-editor",
   // theme: "TODO",
   autoClosingBrackets: true,
   automaticLayout: true,
-  value: snippets.overview,
+  detectIndentation: true,
+  tabSize: 2,
+  value: snippets.loops,
 };
 
 const languageConfiguration = {

--- a/playground/src/playground.html
+++ b/playground/src/playground.html
@@ -26,31 +26,76 @@
     <hr/>
     <!---->
 
-
-    <div>
+    <header>
+      <!-- Code snippets to choose from. -->
+      <!-- Their `value`s are identical to the properties in `snippets.js`. -->
+      <div>
+        <div>
+          <label for="loops-snippet">Loops</label>
+          <input
+            type="radio"
+            id="loops-snippet"
+            name="snippet"
+            value="loops"
+            checked
+          />
+        </div>
+        <div>
+          <label for="selection-snippet">Selection</label>
+          <input
+            type="radio"
+            id="selection-snippet"
+            name="snippet"
+            value="selection"
+          />
+        </div>
+        <div>
+          <label for="block-snippet">Standalone Block</label>
+          <input
+            type="radio"
+            id="block-snippet"
+            name="snippet"
+            value="standaloneBlock"
+          />
+        </div>
+      </div>
+      <!-- The `Run` button and debug options. -->
       <div>
         <div>
           <label for="debug-compilation">Bytecode</label>
           <input
             type="checkbox"
             id="debug-compilation"
-            name="debug-compilation"
+            name="debug option"
           />
         </div>
-        <label for="debug-execution">Execution</label>
-        <input
-          type="checkbox"
-          id="debug-execution"
-          name="debug-execution"
-        />
+        <div>
+          <label for="debug-execution">Execution</label>
+          <input
+            type="checkbox"
+            id="debug-execution"
+            name="debug option"
+          />
+        </div>
+        <!-- The button will become enabled when `Module.onRuntimeInitialized`. -->
+        <button id="thusly-run" disabled>
+          Run
+        </button>
       </div>
-      <!-- The button will become enabled when `Module.onRuntimeInitialized`. -->
-      <button id="run" disabled>
-        Run
-      </button>
-    </div>
-    <div id="editor"></div>
-    <textarea readonly class="emscripten" id="output" rows="10"></textarea>
+    </header>
+
+    <!-- The editor and output. -->
+    <main>
+      <div id="editor"></div>
+      <textarea readonly class="emscripten" id="output" rows="10"></textarea>
+    </main>
+
+    <!-- Extra information. -->
+    <footer>
+      <a href="https://github.com/elle-j/thusly" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </footer>
+
+    <!-- Scripts. -->
 
     <!-- Load the Wasm setup first. -->
     <script src="wasm_setup.js" type="text/javascript"></script>

--- a/playground/src/playground.js
+++ b/playground/src/playground.js
@@ -1,14 +1,37 @@
 import { editor } from "./editor_setup.js";
+import { snippets } from "./snippets.js";
 
+const runButtonElement = document.getElementById("thusly-run");
 const debugCompilationElement = document.getElementById("debug-compilation");
 const debugExecutionElement = document.getElementById("debug-execution");
+const outputElement = document.getElementById("output");
 
-document.getElementById("run").addEventListener("click", () => {
+const loopsSnippetElement = document.getElementById("loops-snippet");
+const selectionSnippetElement = document.getElementById("selection-snippet");
+const blockSnippetElement = document.getElementById("block-snippet");
+
+runButtonElement.addEventListener("click", () => {
   clearOutput();
   const code = editor.getValue();
   run(code, debugCompilationElement.checked, debugExecutionElement.checked);
 });
 
+loopsSnippetElement.addEventListener("click", () => {
+  showSelectedSnippet(loopsSnippetElement.value);
+});
+
+selectionSnippetElement.addEventListener("click", () => {
+  showSelectedSnippet(selectionSnippetElement.value);
+});
+
+blockSnippetElement.addEventListener("click", () => {
+  showSelectedSnippet(blockSnippetElement.value);
+});
+
+function showSelectedSnippet(name) {
+  editor.setValue(snippets[name]);
+}
+
 function clearOutput() {
-  document.getElementById("output").value = "";
+  outputElement.value = "";
 }

--- a/playground/src/snippets.js
+++ b/playground/src/snippets.js
@@ -1,5 +1,20 @@
 export const snippets = {
-  overview: `// Selection
+  loops: `// Bounded loop
+
+foreach value in 0..10
+  @out value
+end
+
+// Unbounded loop
+
+var i: 0
+
+while i < 10 {i +: 1}
+  @out i
+end
+`,
+
+  selection: `// Selection
 
 var age: 30
 if age < 30
@@ -7,30 +22,9 @@ if age < 30
 else
   @out "You were young"
 end
+`,
 
-// Foreach
-
-foreach value in 0..10
-  @out value
-end
-
-var a: 0
-var b: 10
-var c: 2
-
-foreach value in a..b step c
-  @out value
-end
-
-// While
-
-var i: 0
-
-while i < 10 {i +: 1}
-  @out i
-end
-
-// Standalone block
+  standaloneBlock: `// Standalone block
 
 var scopeTest: "global"
 @out scopeTest
@@ -42,5 +36,5 @@ block
 end
 
 @out scopeTest
-`
+`,
 };

--- a/playground/src/wasm_setup.js
+++ b/playground/src/wasm_setup.js
@@ -1,5 +1,5 @@
 const outputElement = document.getElementById("output");
-const runElement = document.getElementById("run");
+const runElement = document.getElementById("thusly-run");
 
 const statusElement = document.getElementById("status");
 const progressElement = document.getElementById("progress");
@@ -29,7 +29,7 @@ function getPrintFn(/*isError = false*/) {
 
     outputElement.value += text + "\n";
     // Go to bottom
-    outputElement.scrollTop = outputElement.scrollHeight;
+    // outputElement.scrollTop = outputElement.scrollHeight;
   };
 };
 


### PR DESCRIPTION
## 🛠 Additions / Changes

### Description

Adds support for choosing between different Thusly code snippets to start with when opening the playground.

## 🗒️ Checklist

| Item                                                | Done | Not Applicable |
|:----------------------------------------------------|:----:|:--------------:|
| Updated the README                                  |      | x              |
| Added the new statement as a synchronization point  |      |  x             |
