### PR TITLE
[playground] Expand click-event area to alleviate selection of code snippet example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A general-purpose programming language coming to life through a custom one-pass 
 
 ## Playground
 
-Try out Thusly in the [interactive playground](./playground).
+Try out Thusly in the WASM-based [interactive playground](./playground) directly in the browser.
 
 ![Thusly Playground](design/media/thusly-playground.png)
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,6 +1,6 @@
 # Interactive Browser Playground for Thusly
 
-An interactive playground in the browser for the Thusly programming language.
+An interactive WASM-based playground in the browser for the Thusly programming language.
 
 ## Live Playground
 

--- a/playground/src/playground.html
+++ b/playground/src/playground.html
@@ -86,7 +86,6 @@
             id="th-debug-compilation"
             class="th-toggle"
             name="debug option"
-            checked
           />
         </div>
         <div class="th-operation">

--- a/playground/src/playground.js
+++ b/playground/src/playground.js
@@ -4,11 +4,6 @@ import { snippets } from "./snippets.js";
 const runButtonElement = document.getElementById("th-run");
 const debugCompilationElement = document.getElementById("th-debug-compilation");
 const debugExecutionElement = document.getElementById("th-debug-execution");
-const outputElement = document.getElementById("th-output");
-
-const loopsSnippetElement = document.getElementById("th-loops-snippet");
-const selectionSnippetElement = document.getElementById("th-selection-snippet");
-const blockSnippetElement = document.getElementById("th-block-snippet");
 
 runButtonElement.addEventListener("click", () => {
   clearOutput();
@@ -16,15 +11,18 @@ runButtonElement.addEventListener("click", () => {
   run(code, debugCompilationElement.checked, debugExecutionElement.checked);
 });
 
-loopsSnippetElement.addEventListener("click", () => {
+const loopsSnippetElement = document.getElementById("th-loops-snippet");
+loopsSnippetElement.parentElement.addEventListener("click", () => {
   showSelectedSnippet(loopsSnippetElement.value);
 });
 
-selectionSnippetElement.addEventListener("click", () => {
+const selectionSnippetElement = document.getElementById("th-selection-snippet");
+selectionSnippetElement.parentElement.addEventListener("click", () => {
   showSelectedSnippet(selectionSnippetElement.value);
 });
 
-blockSnippetElement.addEventListener("click", () => {
+const blockSnippetElement = document.getElementById("th-block-snippet");
+blockSnippetElement.parentElement.addEventListener("click", () => {
   showSelectedSnippet(blockSnippetElement.value);
 });
 
@@ -32,6 +30,7 @@ function showSelectedSnippet(name) {
   editor.setValue(snippets[name]);
 }
 
+const outputElement = document.getElementById("th-output");
 function clearOutput() {
   outputElement.value = "";
 }


### PR DESCRIPTION
## 🛠 Additions / Changes

### Description

Expands the click-event area for the available code snippet examples to now react to the containing `div` (parent) rather than only the radio input button.

This also disables the pre-checked bytecode output option.

## 🗒️ Checklist

| Item                                                | Done | Not Applicable |
|:----------------------------------------------------|:----:|:--------------:|
| Updated the README                                  |  x    |                |
| Added the new statement as a synchronization point  |      |     x           |
| Updated the Playground                              |  x    |                |
