### PR TITLE
Add separate debug mode flag for implementer use

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -5,9 +5,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// Comment/uncomment to disable/enable support for debug flags.
-// (Whether to print output is still controlled via the flags.)
+/// Whether to support debug mode.
+/// Comment/uncomment to disable/enable support for debug flags.
+/// (Whether to print output is still controlled via the flags.)
 #define DEBUG_MODE
+
+/// Flag used by the implementer to output temporary information
+/// when debugging.
+// #define DEBUG_MODE_IMPLEMENTER
 
 extern bool flag_debug_compilation;
 extern bool flag_debug_execution;

--- a/src/gc_object.h
+++ b/src/gc_object.h
@@ -43,6 +43,9 @@ TextObject* claim_c_string(Environment* environment, char* chars, int length);
 TextObject* copy_c_string(Environment* environment, const char* chars, int length);
 void print_object(ThuslyValue value);
 
+// Note: The body of this function is not used directly in a macro since the
+// `value` is used more than once here (twice). This prevents the macro's argument
+// from incorrectly being evaluated twice.
 static inline bool matches_gc_object_type(ThuslyValue value, GCObjectType type) {
   return IS_GC_OBJECT(value) && TO_C_OBJECT_PTR(value)->type == type;
 }

--- a/src/memory.c
+++ b/src/memory.c
@@ -37,7 +37,7 @@ static void free_object(GCObject* object) {
 
 void free_objects(Environment* environment) {
   // -- TEMPORARY --
-  #ifdef DEBUG_MODE
+  #ifdef DEBUG_MODE_IMPLEMENTER
     if (flag_debug_execution)
       printf("FREEING GC OBJECTS..\n");
   #endif

--- a/src/program.c
+++ b/src/program.c
@@ -12,7 +12,7 @@ static void constant_pool_init(ConstantPool* pool) {
 
 static void constant_pool_free(ConstantPool* pool) {
   // -- TEMPORARY --
-  #ifdef DEBUG_MODE
+  #ifdef DEBUG_MODE_IMPLEMENTER
     if (flag_debug_execution)
       printf("FREEING CONSTANT POOL..\n");
   #endif
@@ -44,7 +44,7 @@ void program_init(Program* program) {
 
 void program_free(Program* program) {
   // -- TEMPORARY --
-  #ifdef DEBUG_MODE
+  #ifdef DEBUG_MODE_IMPLEMENTER
     if (flag_debug_execution)
       printf("FREEING PROGRAM..\n");
   #endif

--- a/src/table.c
+++ b/src/table.c
@@ -17,7 +17,7 @@ void table_init(Table* table) {
 
 void table_free(Table* table) {
   // -- TEMPORARY --
-  #ifdef DEBUG_MODE
+  #ifdef DEBUG_MODE_IMPLEMENTER
     if (flag_debug_execution)
       printf("FREEING TABLE..\n");
   #endif

--- a/src/vm.c
+++ b/src/vm.c
@@ -24,7 +24,7 @@ void vm_init(VM* vm) {
 
 void vm_free(VM* vm) {
   // -- TEMPORARY --
-  #ifdef DEBUG_MODE
+  #ifdef DEBUG_MODE_IMPLEMENTER
     if (flag_debug_execution)
       printf("FREEING VM..\n");
   #endif


### PR DESCRIPTION
## 🛠 Additions / Changes

### Description

Adds a separate debug mode flag to control temporary debug outputs relevant to the implementer. This prevents the temporarily used outputs to be displayed to users in the Thusly Playground who opt to enable debug mode.

## 🗒️ Checklist

| Item                                                | Done | Not Applicable |
|:----------------------------------------------------|:----:|:--------------:|
| Updated the README                                  |      |  x              |
| Added the new statement as a synchronization point  |      |     x           |
| Updated the Playground                              |      |   x             |
